### PR TITLE
Use label for ControlLabel

### DIFF
--- a/.changeset/sour-ideas-post.md
+++ b/.changeset/sour-ideas-post.md
@@ -1,0 +1,7 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Use label for ControlLabel
+
+This allows using the htmlFor prop to link the label to the input.

--- a/packages/sigil/src/frontend/controls/content.tsx
+++ b/packages/sigil/src/frontend/controls/content.tsx
@@ -53,20 +53,20 @@ export const ControlParagraph = forwardRef<
 
 ControlParagraph.displayName = 'ControlParagraph';
 
-export type ControlLabelProps = ComponentPropsWithoutRef<'div'> & {
+export type ControlLabelProps = ComponentPropsWithoutRef<'label'> & {
   subgrid?: boolean;
   position?: ControlPosition;
   disabled?: boolean;
   nonMicro?: boolean;
 };
 
-export const ControlLabel = forwardRef<HTMLDivElement, ControlLabelProps>(
+export const ControlLabel = forwardRef<HTMLLabelElement, ControlLabelProps>(
   (
     { className, disabled, nonMicro, position = 'label', subgrid, ...props },
     ref,
   ) => {
     return (
-      <div
+      <label
         {...props}
         ref={ref}
         className={cn(


### PR DESCRIPTION
This allows using the htmlFor prop to link the label to the input.