### PR TITLE
Fix Art-Net Drift

### DIFF
--- a/.changeset/dry-cars-accept.md
+++ b/.changeset/dry-cars-accept.md
@@ -1,0 +1,9 @@
+---
+'@arcanewizards/artnet': patch
+---
+
+Return nextFrameTimeMillis when sending frames
+
+Make it possible for clients to more accurately time sending of artnet packets
+and avoid frame drift by returning information on when the next frame send
+should be.

--- a/.changeset/silly-jars-fix.md
+++ b/.changeset/silly-jars-fix.md
@@ -1,0 +1,12 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Fix Art-Net Drift
+
+The previous implementation of our artnet timecode broadcast would regularly be
+out by about 1 frame, due to us not timing sending of the packets appropriately,
+and rounding down to the nearest frame when converting millisecond timecodes
+to frame timecodes.
+
+We now schedule appropriate timeouts based on when the next frame starts.

--- a/apps/timecode-toolbox/src/outputs/artnet.tsx
+++ b/apps/timecode-toolbox/src/outputs/artnet.tsx
@@ -18,7 +18,6 @@ import {
 import { adjustTimecodeForDelay, getTimecodeInstance } from '../util';
 import { useLogger } from '@arcanewizards/sigil';
 import { ArtNet, createArtnet } from '@arcanewizards/artnet';
-import { TIMECODE_FPS } from '@arcanewizards/artnet/constants';
 import { StateSensitiveComponentProps } from '../types';
 
 type ArtnetOutputConnectionProps = StateSensitiveComponentProps & {
@@ -129,13 +128,35 @@ const ArtnetOutputConnection: FC<ArtnetOutputConnectionProps> = ({
       timecodeState?.state === 'lagging'
     ) {
       const tcState = timecodeState;
-      const interval = setInterval(() => {
+      let timeoutId: NodeJS.Timeout | null = null;
+      const sendNextFrame = () => {
         const time =
           (Date.now() - tcState.effectiveStartTimeMillis) * tcState.speed;
-        artnetInstance.sendTimecode(mode, time);
-      }, 1000 / TIMECODE_FPS[mode]);
+        artnetInstance
+          .sendTimecode(mode, time)
+          .then(({ nextFrameTimeMillis }) => {
+            const delay = nextFrameTimeMillis - time + 1;
+            timeoutId = setTimeout(sendNextFrame, delay);
+          })
+          .catch(() => {
+            scheduleNextFrame();
+          });
+      };
+      const scheduleNextFrame = () => {
+        const time =
+          (Date.now() - tcState.effectiveStartTimeMillis) * tcState.speed;
+        const { nextFrameTimeMillis } = artnetInstance.getNextFrameTiming(
+          mode,
+          time,
+        );
+        const delay = nextFrameTimeMillis - time + 1;
+        timeoutId = setTimeout(sendNextFrame, delay);
+      };
+      scheduleNextFrame();
       return () => {
-        clearInterval(interval);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
       };
     } else if (timecodeState?.state === 'stopped') {
       artnetInstance.sendTimecode(mode, timecodeState?.positionMillis ?? 0);

--- a/packages/artnet/src/index.ts
+++ b/packages/artnet/src/index.ts
@@ -191,9 +191,24 @@ const parseTimecodePacket = (
   };
 };
 
+export type FrameTimingResult = {
+  /**
+   * The time in milliseconds where the next frame will occur after the sent timecode.
+   * This can be used to schedule the next timecode update for smoother updates when sending timecodes in a loop.
+   */
+  nextFrameTimeMillis: number;
+};
+
 export type ArtNet = {
   connect: () => Promise<void>;
-  sendTimecode: (mode: TimecodeMode, timeMillis: number) => Promise<void>;
+  getNextFrameTiming: (
+    mode: TimecodeMode,
+    timeMillis: number,
+  ) => FrameTimingResult;
+  sendTimecode: (
+    mode: TimecodeMode,
+    timeMillis: number,
+  ) => Promise<FrameTimingResult>;
   on<K extends keyof ArtNetEventMap>(
     event: K,
     callback: (...args: ArtNetEventMap[K]) => void,
@@ -348,10 +363,33 @@ export const createArtnet = (config: ArtNetConnectionConfig): ArtNet => {
     return connectPromise;
   };
 
+  const getNextFrameTiming: ArtNet['getNextFrameTiming'] = (
+    mode,
+    timeMillis,
+  ) => {
+    const timecode = getTimecodeFromMillis(mode, timeMillis);
+    // Increment timecode by one frame
+    timecode.frame += 1;
+    if (timecode.frame >= TIMECODE_FPS[mode]) {
+      timecode.frame = 0;
+      timecode.seconds += 1;
+      if (timecode.seconds >= 60) {
+        timecode.seconds = 0;
+        timecode.minutes += 1;
+        if (timecode.minutes >= 60) {
+          timecode.minutes = 0;
+          timecode.hours += 1;
+        }
+      }
+    }
+    const nextFrameTimeMillis = getTimeMillisFromTimecode(timecode);
+    return { nextFrameTimeMillis };
+  };
+
   const sendTimecode: ArtNet['sendTimecode'] = (mode, timeMillis) => {
     if (timeMillis < 0) {
       // Ignore negative timecodes, as they don't exist on ArtNet
-      return Promise.resolve();
+      return Promise.resolve(getNextFrameTiming(mode, timeMillis));
     }
     if (!sendSocket) {
       return Promise.reject(new Error('ArtNet connection has not been opened'));
@@ -396,7 +434,7 @@ export const createArtnet = (config: ArtNetConnectionConfig): ArtNet => {
             events.emit('error', error);
             reject(error);
           } else {
-            resolve();
+            resolve(getNextFrameTiming(mode, timeMillis));
           }
         },
       ),
@@ -411,6 +449,7 @@ export const createArtnet = (config: ArtNetConnectionConfig): ArtNet => {
 
   return {
     connect,
+    getNextFrameTiming,
     sendTimecode,
     on,
     addListener,


### PR DESCRIPTION
The previous implementation of our artnet timecode broadcast would regularly be out by about 1 frame, due to us not timing sending of the packets appropriately, and rounding down to the nearest frame when converting millisecond timecodes to frame timecodes.

We now schedule appropriate timeouts based on when the next frame starts.

fixes #30