### PR TITLE
Display output link status clearly

### DIFF
--- a/.changeset/better-jokes-camp.md
+++ b/.changeset/better-jokes-camp.md
@@ -1,0 +1,5 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Correct some input/output mis-labelling

--- a/.changeset/fast-bears-sin.md
+++ b/.changeset/fast-bears-sin.md
@@ -1,0 +1,5 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Allow using hint with sigilColorUsage

--- a/.changeset/silent-bananas-move.md
+++ b/.changeset/silent-bananas-move.md
@@ -1,0 +1,10 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Clearly display when an output is linked to something
+
+Previously, it wasn't obvious when an output was connected to an input or
+generator, and which input or generator was linked.
+
+This is now prominently displayed underneath the output type & name.

--- a/apps/timecode-toolbox-desktop/package.json
+++ b/apps/timecode-toolbox-desktop/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --max-warnings 0 --fix",
     "check:types": "tsc --noEmit",
-    "clean": "rm -rf dist",
+    "clean": "rm -rf dist && rm -rf out",
     "build": "pnpm check:types && pnpm clean && cp ../../LICENSE ./LICENSE &&pnpm build:main && pnpm build:preload && pnpm build:frontend",
     "build:workspace": "pnpm -r --filter @arcanewizards/timecode-toolbox-desktop... build",
     "build:main": "esbuild src/main.ts --bundle --platform=node --format=cjs --target=node20 --external:electron --external:@arcanewizards/electron-media-service --outfile=dist/main.js",

--- a/apps/timecode-toolbox-desktop/tsconfig.json
+++ b/apps/timecode-toolbox-desktop/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/react.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     // Disable custom conditions, as we want it to use the raw JS here
     "customConditions": [],
     "sourceMap": true,

--- a/apps/timecode-toolbox/package.json
+++ b/apps/timecode-toolbox/package.json
@@ -32,10 +32,11 @@
     "dist"
   ],
   "scripts": {
-    "build": "pnpm check:types && rm -rf dist && cp ../../LICENSE ./LICENSE && tsup && pnpm build:entrypoint && pnpm build:frontend && pnpm build:styles && check-export-map",
+    "build": "pnpm check:types && pnpm clean && cp ../../LICENSE ./LICENSE && tsup && pnpm build:entrypoint && pnpm build:frontend && pnpm build:styles && check-export-map",
     "build:entrypoint": "arcane-build-frontend --entry src/components/frontend/entrypoint.ts --outfile dist/entrypoint.js --sourcemap",
     "build:frontend": "arcane-build-frontend --entry src/components/frontend/index.tsx --outfile dist/frontend.js --sourcemap",
     "build:styles": "tailwindcss -i ./src/components/frontend/frontend.css -o ./dist/entrypoint.css",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",

--- a/apps/timecode-toolbox/src/components/frontend/constants.ts
+++ b/apps/timecode-toolbox/src/components/frontend/constants.ts
@@ -33,6 +33,7 @@ export const STRINGS = {
   },
   inputs: {
     title: 'INPUTS',
+    unnamed: 'Unnamed Input',
     noChildren: 'No inputs yet. Please add one using the buttons below.',
     addButton: (protocol: string) => `Add ${protocol}`,
     addDialog: (protocol: string) => `Add ${protocol} Input`,
@@ -58,6 +59,7 @@ export const STRINGS = {
   delay: (delayMs: number) => `Delay: ${MS_FORMAT.format(delayMs)}`,
   generators: {
     title: 'GENERATORS',
+    unnamed: 'Unnamed Generator',
     noChildren: 'No generators yet. Please add one using the buttons below.',
     type: {
       clock: 'Clock',
@@ -70,6 +72,7 @@ export const STRINGS = {
   },
   outputs: {
     title: 'OUTPUTS',
+    unnamed: 'Unnamed Output',
     noChildren: 'No outputs yet. Please add one using the buttons below.',
     addButton: (protocol: string) => `Add ${protocol}`,
     addDialog: (protocol: string) => `Add ${protocol} Output`,

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -212,7 +212,7 @@ const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
         )}
       >
         {headerComponents && (
-          <div className="flex flex-wrap gap-0.25">{headerComponents}</div>
+          <div className="flex gap-0.25">{headerComponents}</div>
         )}
         <SizeAwareDiv
           className={cn(
@@ -356,6 +356,13 @@ const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
   );
 };
 
+export type LinkedSourceInfo = {
+  color: SigilColor | undefined;
+  type: string;
+  name: string[];
+  namePlaceholder: string;
+};
+
 type TimecodeTreeDisplayProps = {
   config: UniversalConfig;
   /**
@@ -364,6 +371,7 @@ type TimecodeTreeDisplayProps = {
   id: TimecodeInstanceId;
   type: string;
   name: string[];
+  link?: LinkedSourceInfo;
   color: SigilColor | undefined;
   timecode: TimecodeGroup | TimecodeInstance | null;
   namePlaceholder: string;
@@ -394,6 +402,7 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
   id,
   type,
   name,
+  link,
   color,
   timecode,
   namePlaceholder,
@@ -443,23 +452,62 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
         config={config}
         headerComponents={
           <>
-            <div className="flex grow items-start gap-0.25">
-              <div
-                className="
-                  m-0.25 rounded-md border border-sigil-bg-light
-                  bg-timecode-usage-foreground px-1 py-0.25 text-sigil-control
-                  text-timecode-usage-text
-                "
-              >
-                {type}
-              </div>
-              <div
-                className={cn(
-                  'grow basis-0 truncate p-0.5',
-                  cnd(name.length, 'font-bold', 'italic opacity-50'),
+            <div className="flex grow basis-0 items-start gap-0.25">
+              <div className="grow">
+                <div className="flex items-center gap-0.25">
+                  <div
+                    className="
+                      m-0.25 rounded-md border border-sigil-bg-light
+                      bg-timecode-usage-foreground px-1 py-0.25
+                      text-sigil-control text-timecode-usage-text
+                    "
+                  >
+                    {type}
+                  </div>
+                  <div
+                    className={cn(
+                      'w-0 grow truncate p-0.5',
+                      cnd(name.length, 'font-bold', 'italic opacity-50'),
+                    )}
+                  >
+                    {name.length ? name.join(' / ') : namePlaceholder}
+                  </div>
+                </div>
+                {link && (
+                  <div
+                    className="
+                      flex items-center gap-0.25 text-timecode-usage-foreground
+                    "
+                    style={cssSigilColorUsageVariables(
+                      'timecode-usage',
+                      // Override timecode color with the user hint preferences
+                      // when no color is specified
+                      // as that will be what's used by the linked input/generator
+                      sigilColorUsage(link.color ?? 'hint'),
+                    )}
+                  >
+                    <div
+                      className="
+                        m-0.25 flex items-center gap-0.25 rounded-md border
+                        border-sigil-bg-light bg-timecode-usage-foreground px-1
+                        py-0.25 text-sigil-control text-timecode-usage-text
+                      "
+                    >
+                      <Icon icon="link" className="text-[120%]" />
+                      <span>{link.type}</span>
+                    </div>
+                    <div
+                      className={cn(
+                        'w-0 grow truncate p-0.5',
+                        cnd(link.name.length, 'font-bold', 'italic opacity-50'),
+                      )}
+                    >
+                      {link.name.length
+                        ? link.name.join(' / ')
+                        : link.namePlaceholder}
+                    </div>
+                  </div>
                 )}
-              >
-                {name.length ? name.join(' / ') : namePlaceholder}
               </div>
             </div>
             <ControlButtonGroup className="rounded-md bg-sigil-bg-light">
@@ -530,7 +578,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         type: STRINGS.protocols[c.definition.type].short,
         name: c.name ? [c.name] : [],
         color: c.color,
-        namePlaceholder: `Unnamed Input`,
+        namePlaceholder: STRINGS.inputs.unnamed,
       };
     } else if (isGeneratorInstanceId(id)) {
       const c = config.generators[id[1]];
@@ -542,7 +590,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         type: STRINGS.generators.type[c.definition.type],
         name: c.name ? [c.name] : [],
         color: c.color,
-        namePlaceholder: `Unnamed Generator`,
+        namePlaceholder: STRINGS.generators.unnamed,
       };
     } else {
       const c = config.outputs[id[1]];
@@ -554,7 +602,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         type: STRINGS.protocols[c.definition.type].short,
         name: c.name ? [c.name] : [],
         color: c.color,
-        namePlaceholder: `Unnamed Output`,
+        namePlaceholder: STRINGS.outputs.unnamed,
       };
     }
   }, [id, config]);

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
@@ -250,7 +250,7 @@ const GeneratorDisplay: FC<GeneratorDisplayProps> = ({
       name={config.name ? [config.name] : []}
       color={config.color}
       timecode={state?.timecode ?? null}
-      namePlaceholder={`Unnamed Generator`}
+      namePlaceholder={STRINGS.generators.unnamed}
       buttons={
         <>
           <ControlButton

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
@@ -412,7 +412,7 @@ export const InputDisplay: FC<InputDisplayProps> = ({
       name={config.name ? [config.name] : []}
       color={config.color}
       timecode={state?.timecode ?? null}
-      namePlaceholder={`Unnamed Input`}
+      namePlaceholder={STRINGS.inputs.unnamed}
       buttons={
         <>
           <ControlButton

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -488,7 +488,7 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
           <>
             <ControlButton
               variant="large"
-              title={config.enabled ? 'Stop Input' : 'Start Input'}
+              title={config.enabled ? 'Stop Output' : 'Start Output'}
               onClick={toggleEnabled}
               icon={config.enabled ? 'stop' : 'play_arrow'}
             />

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -27,7 +27,7 @@ import {
   TimecodeInstance,
   ToolboxRootGetNetworkInterfacesReturn,
 } from '../../proto';
-import { TimecodeTreeDisplay } from './core/timecode-display';
+import { LinkedSourceInfo, TimecodeTreeDisplay } from './core/timecode-display';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import {
   ChangeCommitContext,
@@ -413,7 +413,7 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
   setAssignToOutput,
 }) => {
   const applicationState = useApplicationState();
-  const { updateConfig } = useContext(ConfigContext);
+  const { config: allConfig, updateConfig } = useContext(ConfigContext);
   const clearLink = useCallback(() => {
     updateConfig((current) => {
       const currentOutput = current.outputs?.[uuid];
@@ -444,6 +444,39 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
       config.link && getTimecodeInstance(applicationState, config.link);
     return augmentUpstreamTimecodeWithOutputMetadata(tc, config);
   }, [applicationState, config]);
+
+  const link: LinkedSourceInfo | undefined = useMemo(() => {
+    if (!config.link) {
+      return undefined;
+    }
+
+    let info: LinkedSourceInfo | undefined = undefined;
+    if (config.link[0] === 'input') {
+      const input = allConfig.inputs?.[config.link[1]];
+      if (input) {
+        info = {
+          color: input.color,
+          type: STRINGS.protocols[input.definition.type].short,
+          name: input.name ? [input.name] : [],
+          namePlaceholder: STRINGS.inputs.unnamed,
+        };
+      }
+      // TODO: Handle timecode groups and nested names
+    } else if (config.link[0] === 'generator') {
+      const generator = allConfig.generators?.[config.link[1]];
+      if (generator) {
+        info = {
+          color: generator.color,
+          type: STRINGS.generators.type[generator.definition.type],
+          name: generator.name ? [generator.name] : [],
+          namePlaceholder: STRINGS.generators.unnamed,
+        };
+      }
+      // TODO: Handle timecode groups and nested names
+    }
+
+    return info;
+  }, [config.link, allConfig]);
 
   const toggleEnabled = useCallback(() => {
     updateConfig((current) => {
@@ -483,7 +516,8 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
         name={config.name ? [config.name] : []}
         color={config.color}
         timecode={config.enabled ? timecode : null}
-        namePlaceholder={`Unnamed Output`}
+        namePlaceholder={STRINGS.outputs.unnamed}
+        link={link}
         buttons={
           <>
             <ControlButton

--- a/apps/timecode-toolbox/src/inputs/artnet.tsx
+++ b/apps/timecode-toolbox/src/inputs/artnet.tsx
@@ -121,7 +121,7 @@ const ArtnetInputConnection: FC<ArtnetInputConnectionProps> = ({
       .then(() => {
         artnet = created;
         setArtnetInstance(created);
-        log.info('ArtNet Timecode output initialized');
+        log.info('ArtNet Timecode input initialized');
         setConnection({ ...connectionConfig, status: 'active' });
       })
       .catch((err) => {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "turbo build",
+    "clean": "turbo clean",
     "pre-deploy:web": "turbo pre-deploy --filter=web",
     "check:types": "turbo check:types",
     "dev": "turbo dev",

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -21,7 +21,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup && check-export-map",
+    "build": "pnpm clean && tsup && check-export-map",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",

--- a/packages/apis/tsconfig.json
+++ b/packages/apis/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "moduleResolution": "nodenext",
   },
   "include": ["src"],

--- a/packages/artnet/package.json
+++ b/packages/artnet/package.json
@@ -28,7 +28,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup && check-export-map",
+    "build": "pnpm clean && tsup && check-export-map",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",

--- a/packages/artnet/tsconfig.json
+++ b/packages/artnet/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "moduleResolution": "nodenext",
   },
   "include": ["src"],

--- a/packages/net-utils/package.json
+++ b/packages/net-utils/package.json
@@ -22,7 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup && check-export-map",
+    "build": "pnpm clean && tsup && check-export-map",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",

--- a/packages/net-utils/tsconfig.json
+++ b/packages/net-utils/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "moduleResolution": "nodenext",
   },
   "include": ["src"],

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -104,8 +104,9 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup && pnpm build:styles && check-export-map",
+    "build": "pnpm clean && tsup && pnpm build:styles && check-export-map",
     "build:styles": "tailwindcss -i ./src/frontend/styles/sigil.css -o ./dist/frontend/styles/sigil.css && cp ./src/frontend/styles/theme.css ./dist/frontend/styles/theme.css && cp ./src/frontend/styles/base.css ./dist/frontend/styles/base.css",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",

--- a/packages/sigil/src/frontend/styling.ts
+++ b/packages/sigil/src/frontend/styling.ts
@@ -33,7 +33,7 @@ export type SigilUsageColorUsage = {
 };
 
 export const sigilColorUsage = (
-  color: SigilUsageColor,
+  color: SigilUsageColor | 'hint',
 ): SigilUsageColorUsage => ({
   text: `var(--sigil-usage-${color}-text)`,
   foreground: `var(--sigil-usage-${color}-foreground)`,

--- a/packages/sigil/tsconfig.json
+++ b/packages/sigil/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/react.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "module": "esnext",
     "moduleResolution": "bundler",
   },

--- a/packages/tcnet/package.json
+++ b/packages/tcnet/package.json
@@ -34,7 +34,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf dist && tsup && check-export-map",
+    "build": "pnpm clean && tsup && check-export-map",
+    "clean": "rm -rf dist",
     "check:types": "tsc --noEmit",
     "lint": "eslint . --max-warnings 0"
   },

--- a/packages/tcnet/tsconfig.json
+++ b/packages/tcnet/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@arcanewizards/typescript-config/base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "rootDir": "src",
     "moduleResolution": "nodenext"
   },
   "include": ["src"],

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,9 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
+    "clean": {
+      "dependsOn": ["^clean"]
+    },
     "check:types": {
       "dependsOn": ["^check:types"]
     },


### PR DESCRIPTION
Clearly display when an output is linked to something

Previously, it wasn't obvious when an output was connected to an input or generator, and which input or generator was linked.

This is now prominently displayed underneath the output type & name.

fixes #55 