### PR TITLE
Make paused/disabled state more obvious & consistent

### DIFF
--- a/.changeset/lazy-chefs-swim.md
+++ b/.changeset/lazy-chefs-swim.md
@@ -1,0 +1,8 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Make it more obvious when output/input is paused/disabled
+
+Replace the timecode display with a pause icon when an input/output is disabled,
+making it very clear when a timecode won't be sending/receiving a signal.

--- a/apps/timecode-toolbox/src/components/frontend/constants.ts
+++ b/apps/timecode-toolbox/src/components/frontend/constants.ts
@@ -34,6 +34,9 @@ export const STRINGS = {
   inputs: {
     title: 'INPUTS',
     unnamed: 'Unnamed Input',
+    enable: 'Enable Input',
+    disable: 'Disable Input',
+    edit: 'Edit Input',
     noChildren: 'No inputs yet. Please add one using the buttons below.',
     addButton: (protocol: string) => `Add ${protocol}`,
     addDialog: (protocol: string) => `Add ${protocol} Input`,
@@ -60,6 +63,7 @@ export const STRINGS = {
   generators: {
     title: 'GENERATORS',
     unnamed: 'Unnamed Generator',
+    edit: 'Edit Generator',
     noChildren: 'No generators yet. Please add one using the buttons below.',
     type: {
       clock: 'Clock',
@@ -73,6 +77,10 @@ export const STRINGS = {
   outputs: {
     title: 'OUTPUTS',
     unnamed: 'Unnamed Output',
+    enable: 'Enable Output',
+    disable: 'Disable Output',
+    link: 'Link Output',
+    edit: 'Edit Output',
     noChildren: 'No outputs yet. Please add one using the buttons below.',
     addButton: (protocol: string) => `Add ${protocol}`,
     addDialog: (protocol: string) => `Add ${protocol} Output`,

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -18,6 +18,7 @@ import {
   isOutputInstanceId,
   isInputInstanceId,
   isGeneratorInstanceId,
+  ToolboxConfig,
 } from '../../../proto';
 import { displayMillis } from '../util';
 import { StageContext } from '@arcanejs/toolkit-frontend';
@@ -363,6 +364,42 @@ export type LinkedSourceInfo = {
   namePlaceholder: string;
 };
 
+export const getLinkedSourceInfo = (
+  link: TimecodeInstanceId | null,
+  config: ToolboxConfig,
+): LinkedSourceInfo | undefined => {
+  if (!link) {
+    return undefined;
+  }
+
+  let info: LinkedSourceInfo | undefined = undefined;
+  if (link[0] === 'input') {
+    const input = config.inputs?.[link[1]];
+    if (input) {
+      info = {
+        color: input.color,
+        type: STRINGS.protocols[input.definition.type].short,
+        name: input.name ? [input.name] : [],
+        namePlaceholder: STRINGS.inputs.unnamed,
+      };
+    }
+    // TODO: Handle timecode groups and nested names
+  } else if (link[0] === 'generator') {
+    const generator = config.generators?.[link[1]];
+    if (generator) {
+      info = {
+        color: generator.color,
+        type: STRINGS.generators.type[generator.definition.type],
+        name: generator.name ? [generator.name] : [],
+        namePlaceholder: STRINGS.generators.unnamed,
+      };
+    }
+    // TODO: Handle timecode groups and nested names
+  }
+
+  return info;
+};
+
 type TimecodeTreeDisplayProps = {
   config: UniversalConfig;
   /**
@@ -567,6 +604,16 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
     }
   }, [applicationState, id, config.outputs]);
 
+  const linkedSourceInfo = useMemo(() => {
+    if (isOutputInstanceId(id)) {
+      const c = config.outputs[id[1]];
+      if (c?.link) {
+        return getLinkedSourceInfo(c.link, config);
+      }
+    }
+    return undefined;
+  }, [id, config]);
+
   const instanceConfig: FullscreenTimecodeConfig | null = useMemo(() => {
     if (isInputInstanceId(id)) {
       const c = config.inputs[id[1]];
@@ -633,6 +680,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         timecode={timecode}
         assignToOutput={null}
         buttons={null}
+        link={linkedSourceInfo}
         {...instanceConfig}
       />
     </div>

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -148,6 +148,7 @@ type TimecodeDisplayProps = {
   timecode: TimecodeInstance;
   config: UniversalConfig;
   headerComponents?: React.ReactNode;
+  disabled: boolean;
 };
 
 const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
@@ -155,6 +156,7 @@ const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
   timecode: { state, metadata },
   config,
   headerComponents,
+  disabled,
 }) => {
   const { handlers, callHandler } = useApplicationHandlers();
 
@@ -216,33 +218,46 @@ const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
           <div className="flex gap-0.25">{headerComponents}</div>
         )}
         <SizeAwareDiv
-          className={cn(
-            'relative min-h-timecode-min-height grow',
-            cnd(state?.state === 'stopped', 'opacity-50'),
-            cnd(
-              hooks?.play && hooks?.pause,
-              `
-                cursor-pointer
-                hover:opacity-100
-              `,
-            ),
-          )}
+          className="relative min-h-timecode-min-height grow"
           onClick={toggle}
         >
-          <div className="absolute inset-0 flex items-center justify-center">
-            <span className={cn('font-mono text-timecode-adaptive')}>
-              {state.state === 'none' ? (
-                '--:--:--:---'
-              ) : state.state === 'stopped' ? (
-                displayMillis(state.positionMillis)
-              ) : (
-                <ActiveTimecodeText
-                  effectiveStartTimeMillis={state.effectiveStartTimeMillis}
-                  speed={state.speed}
-                />
+          {disabled ? (
+            <SizeAwareDiv
+              className="
+                pointer-events-none absolute inset-0 flex items-center
+                justify-center
+              "
+            >
+              <Icon icon="pause" className="text-timecode-adaptive" />
+            </SizeAwareDiv>
+          ) : (
+            <div
+              className={cn(
+                'absolute inset-0 flex items-center justify-center',
+                cnd(state?.state === 'stopped', 'opacity-50'),
+                cnd(
+                  hooks?.play && hooks?.pause,
+                  `
+                    cursor-pointer
+                    hover:opacity-100
+                  `,
+                ),
               )}
-            </span>
-          </div>
+            >
+              <span className={cn('font-mono text-timecode-adaptive')}>
+                {state.state === 'none' ? (
+                  '--:--:--:---'
+                ) : state.state === 'stopped' ? (
+                  displayMillis(state.positionMillis)
+                ) : (
+                  <ActiveTimecodeText
+                    effectiveStartTimeMillis={state.effectiveStartTimeMillis}
+                    speed={state.speed}
+                  />
+                )}
+              </span>
+            </div>
+          )}
         </SizeAwareDiv>
         {hooks?.pause || hooks?.play ? (
           <div className="flex justify-center gap-px">
@@ -410,7 +425,7 @@ type TimecodeTreeDisplayProps = {
   name: string[];
   link?: LinkedSourceInfo;
   color: SigilColor | undefined;
-  timecode: TimecodeGroup | TimecodeInstance | null;
+  timecode: 'disabled' | TimecodeGroup | TimecodeInstance | null;
   namePlaceholder: string;
   buttons: ReactNode;
   /**
@@ -457,8 +472,13 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
     }
   }, [id, openNewWidow]);
 
-  name = timecode?.name ? [...name, timecode.name] : name;
-  if (isTimecodeGroup(timecode) && Object.values(timecode.timecodes).length) {
+  name =
+    timecode !== 'disabled' && timecode?.name ? [...name, timecode.name] : name;
+  if (
+    timecode !== 'disabled' &&
+    isTimecodeGroup(timecode) &&
+    Object.values(timecode.timecodes).length
+  ) {
     return Object.entries(timecode.timecodes).map(([key, child]) => (
       <TimecodeTreeDisplay
         config={config}
@@ -485,7 +505,12 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
     >
       <TimecodeDisplay
         id={id}
-        timecode={isTimecodeInstance(timecode) ? timecode : EMPTY_TIMECODE}
+        timecode={
+          timecode !== 'disabled' && isTimecodeInstance(timecode)
+            ? timecode
+            : EMPTY_TIMECODE
+        }
+        disabled={timecode === 'disabled'}
         config={config}
         headerComponents={
           <>
@@ -581,6 +606,7 @@ type FullscreenTimecodeConfig = {
   name: string[];
   color: SigilColor | undefined;
   namePlaceholder: string;
+  disabled: boolean;
 };
 
 export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
@@ -626,6 +652,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         name: c.name ? [c.name] : [],
         color: c.color,
         namePlaceholder: STRINGS.inputs.unnamed,
+        disabled: !c.enabled,
       };
     } else if (isGeneratorInstanceId(id)) {
       const c = config.generators[id[1]];
@@ -638,6 +665,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         name: c.name ? [c.name] : [],
         color: c.color,
         namePlaceholder: STRINGS.generators.unnamed,
+        disabled: false,
       };
     } else {
       const c = config.outputs[id[1]];
@@ -650,6 +678,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
         name: c.name ? [c.name] : [],
         color: c.color,
         namePlaceholder: STRINGS.outputs.unnamed,
+        disabled: !c.enabled,
       };
     }
   }, [id, config]);
@@ -677,7 +706,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
     >
       <TimecodeTreeDisplay
         id={id}
-        timecode={timecode}
+        timecode={instanceConfig.disabled ? 'disabled' : timecode}
         assignToOutput={null}
         buttons={null}
         link={linkedSourceInfo}

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -594,7 +594,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
       return getTimecodeInstance(applicationState, id);
     } else {
       const c = config.outputs[id[1]];
-      if (!c) {
+      if (!c || !c.enabled) {
         return null;
       }
       return augmentUpstreamTimecodeWithOutputMetadata(

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
@@ -255,7 +255,7 @@ const GeneratorDisplay: FC<GeneratorDisplayProps> = ({
         <>
           <ControlButton
             variant="large"
-            title="Edit Generator"
+            title={STRINGS.generators.edit}
             onClick={() =>
               setDialogMode({
                 section: {

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
@@ -411,19 +411,21 @@ export const InputDisplay: FC<InputDisplayProps> = ({
       type={STRINGS.protocols[config.definition.type].short}
       name={config.name ? [config.name] : []}
       color={config.color}
-      timecode={state?.timecode ?? null}
+      timecode={config.enabled ? (state?.timecode ?? null) : 'disabled'}
       namePlaceholder={STRINGS.inputs.unnamed}
       buttons={
         <>
           <ControlButton
             variant="large"
-            title={config.enabled ? 'Stop Input' : 'Start Input'}
+            title={
+              config.enabled ? STRINGS.inputs.disable : STRINGS.inputs.enable
+            }
             onClick={toggleEnabled}
-            icon={config.enabled ? 'stop' : 'play_arrow'}
+            icon={config.enabled ? 'pause' : 'play_arrow'}
           />
           <ControlButton
             variant="large"
-            title="Edit Input"
+            title={STRINGS.inputs.edit}
             onClick={() =>
               setDialogMode({
                 section: { type: 'inputs', input: config.definition.type },

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -491,27 +491,31 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
         type={STRINGS.protocols[config.definition.type].short}
         name={config.name ? [config.name] : []}
         color={config.color}
-        timecode={config.enabled ? timecode : null}
+        timecode={config.enabled ? timecode : 'disabled'}
         namePlaceholder={STRINGS.outputs.unnamed}
         link={link}
         buttons={
           <>
             <ControlButton
               variant="large"
-              title={config.enabled ? 'Stop Output' : 'Start Output'}
+              title={
+                config.enabled
+                  ? STRINGS.outputs.disable
+                  : STRINGS.outputs.enable
+              }
               onClick={toggleEnabled}
-              icon={config.enabled ? 'stop' : 'play_arrow'}
+              icon={config.enabled ? 'pause' : 'play_arrow'}
             />
             <ControlButton
               variant="large"
-              title="Link Output"
+              title={STRINGS.outputs.link}
               active={assignToOutput === uuid}
               onClick={linkCallback}
               icon={config.link ? 'link' : 'link_off'}
             />
             <ControlButton
               variant="large"
-              title="Edit Output"
+              title={STRINGS.outputs.edit}
               onClick={() =>
                 setDialogMode({
                   section: { type: 'outputs', output: config.definition.type },

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -27,7 +27,11 @@ import {
   TimecodeInstance,
   ToolboxRootGetNetworkInterfacesReturn,
 } from '../../proto';
-import { LinkedSourceInfo, TimecodeTreeDisplay } from './core/timecode-display';
+import {
+  getLinkedSourceInfo,
+  LinkedSourceInfo,
+  TimecodeTreeDisplay,
+} from './core/timecode-display';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import {
   ChangeCommitContext,
@@ -445,38 +449,10 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
     return augmentUpstreamTimecodeWithOutputMetadata(tc, config);
   }, [applicationState, config]);
 
-  const link: LinkedSourceInfo | undefined = useMemo(() => {
-    if (!config.link) {
-      return undefined;
-    }
-
-    let info: LinkedSourceInfo | undefined = undefined;
-    if (config.link[0] === 'input') {
-      const input = allConfig.inputs?.[config.link[1]];
-      if (input) {
-        info = {
-          color: input.color,
-          type: STRINGS.protocols[input.definition.type].short,
-          name: input.name ? [input.name] : [],
-          namePlaceholder: STRINGS.inputs.unnamed,
-        };
-      }
-      // TODO: Handle timecode groups and nested names
-    } else if (config.link[0] === 'generator') {
-      const generator = allConfig.generators?.[config.link[1]];
-      if (generator) {
-        info = {
-          color: generator.color,
-          type: STRINGS.generators.type[generator.definition.type],
-          name: generator.name ? [generator.name] : [],
-          namePlaceholder: STRINGS.generators.unnamed,
-        };
-      }
-      // TODO: Handle timecode groups and nested names
-    }
-
-    return info;
-  }, [config.link, allConfig]);
+  const link: LinkedSourceInfo | undefined = useMemo(
+    () => getLinkedSourceInfo(config.link, allConfig),
+    [config.link, allConfig],
+  );
 
   const toggleEnabled = useCallback(() => {
     updateConfig((current) => {


### PR DESCRIPTION
Replace the timecode display with a pause icon when an input/output is disabled,
making it very clear when a timecode won't be sending/receiving a signal.

Also ensure that full-screen windows also take this into account.

Fixes #31 