### PR TITLE
Avoid cleaning out during desktop build

### DIFF
--- a/apps/timecode-toolbox-desktop/package.json
+++ b/apps/timecode-toolbox-desktop/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --max-warnings 0 --fix",
     "check:types": "tsc --noEmit",
-    "clean": "rm -rf dist && rm -rf out",
+    "clean": "rm -rf dist",
     "build": "pnpm check:types && pnpm clean && cp ../../LICENSE ./LICENSE &&pnpm build:main && pnpm build:preload && pnpm build:frontend",
     "build:workspace": "pnpm -r --filter @arcanewizards/timecode-toolbox-desktop... build",
     "build:main": "esbuild src/main.ts --bundle --platform=node --format=cjs --target=node20 --external:electron --external:@arcanewizards/electron-media-service --outfile=dist/main.js",


### PR DESCRIPTION
This was deleting the dmg file for other architectures