### PR TITLE
Address Art-Net output loop forking.

### DIFF
--- a/.changeset/tasty-things-smoke.md
+++ b/.changeset/tasty-things-smoke.md
@@ -1,0 +1,12 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Address Art-Net output loop forking.
+
+Maintaining a custom frame event loop using `setTimeout` caused previous
+ArtNet states to continue sending even though they should have stopped.
+
+This issue has now been addressed.
+
+fixes #66

--- a/apps/timecode-toolbox/src/outputs/artnet.tsx
+++ b/apps/timecode-toolbox/src/outputs/artnet.tsx
@@ -128,8 +128,17 @@ const ArtnetOutputConnection: FC<ArtnetOutputConnectionProps> = ({
       timecodeState?.state === 'lagging'
     ) {
       const tcState = timecodeState;
+      let transmit = true;
       let timeoutId: NodeJS.Timeout | null = null;
       const sendNextFrame = () => {
+        if (!transmit) {
+          /*
+           * A timeout may still be requested in the then/catch of the
+           * sendTimecode promise after the component has been unmounted.
+           * so we need to check if we should still transmit before sending the next frame.
+           */
+          return;
+        }
         const time =
           (Date.now() - tcState.effectiveStartTimeMillis) * tcState.speed;
         artnetInstance
@@ -154,6 +163,7 @@ const ArtnetOutputConnection: FC<ArtnetOutputConnectionProps> = ({
       };
       scheduleNextFrame();
       return () => {
+        transmit = false;
         if (timeoutId) {
           clearTimeout(timeoutId);
         }


### PR DESCRIPTION
Maintaining a custom frame event loop using `setTimeout` caused previous ArtNet states to continue sending even though they should have stopped.

This issue has now been addressed.

fixes #66