### PR TITLE
Refactor close confirmation API

### DIFF
--- a/.changeset/six-windows-jog.md
+++ b/.changeset/six-windows-jog.md
@@ -1,9 +1,0 @@
----
-'@arcanewizards/sigil': patch
----
-
-Refactor close confirmation API
-
-Make it possible for electron apps to block closing windows properly by
-listening to the `close` event,
-by introducing a new API for registering window close confirmation behavior.

--- a/.changeset/six-windows-jog.md
+++ b/.changeset/six-windows-jog.md
@@ -1,0 +1,9 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Refactor close confirmation API
+
+Make it possible for electron apps to block closing windows properly by
+listening to the `close` event,
+by introducing a new API for registering window close confirmation behavior.

--- a/apps/timecode-toolbox-desktop/src/frontend.ts
+++ b/apps/timecode-toolbox-desktop/src/frontend.ts
@@ -2,6 +2,7 @@ import '@arcanewizards/timecode-toolbox/frontend';
 import '@arcanewizards/timecode-toolbox/entrypoint.css';
 
 import type { ElectronAPI } from './preload';
+import { BrowserCloseListener } from '@arcanewizards/sigil/frontend';
 
 declare global {
   interface Window {
@@ -15,6 +16,20 @@ if (
 ) {
   throw new Error('Timecode Toolbox frontend is not loaded properly.');
 }
+
+const closeListeners = new Set<BrowserCloseListener>();
+
+window.electronAPI?.onCloseRequested(() => {
+  for (const listener of closeListeners) {
+    const result = listener();
+    if (result.action === 'confirm') {
+      window.electronAPI?.confirmClose(result.confirmation);
+      return;
+    }
+  }
+  // If no listener returned a 'confirm' action, directly close the window
+  window.close();
+});
 
 window.startTimecodeToolboxServerFrontend({
   appListenerChangesHandledExternally: !!window.electronAPI,
@@ -35,11 +50,10 @@ window.startTimecodeToolboxServerFrontend({
   },
   selectDirectory: window.electronAPI?.selectDirectory ?? null,
   openDevTools: window.electronAPI?.openDevTools ?? null,
-  confirmClose: (message: string) => {
-    if (window.electronAPI) {
-      window.electronAPI.confirmClose(message);
-    }
-  },
+  addCloseListener: (listener: BrowserCloseListener) =>
+    closeListeners.add(listener),
+  removeCloseListener: (listener: BrowserCloseListener) =>
+    closeListeners.delete(listener),
   mediaSession:
     window.electronAPI?.mediaSession ?? window.createBrowserMediaSession(),
 });

--- a/apps/timecode-toolbox-desktop/src/preload.ts
+++ b/apps/timecode-toolbox-desktop/src/preload.ts
@@ -31,6 +31,8 @@ const ELECTRON_API = {
   confirmClose: (message: string) => {
     ipcRenderer.send('confirm-close', message);
   },
+  onCloseRequested: (callback: () => void) =>
+    ipcRenderer.on('window-close', () => callback()),
   mediaSession,
 };
 

--- a/packages/sigil/CHANGELOG.md
+++ b/packages/sigil/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @arcanewizards/sigil
 
+## 0.1.8
+
+### Patch Changes
+
+- 661bff4: Refactor close confirmation API
+
+  Make it possible for electron apps to block closing windows properly by
+  listening to the `close` event,
+  by introducing a new API for registering window close confirmation behavior.
+
 ## 0.1.7
 
 ### Patch Changes

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arcanewizards/sigil",
   "description": "Application framework for A/V applications, built on-top of arcanejs",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/packages/sigil/src/frontend.ts
+++ b/packages/sigil/src/frontend.ts
@@ -6,6 +6,8 @@ export {
   useBrowserContext,
 } from './frontend/browser-context';
 export type {
+  BrowserCloseListener,
+  BrowserCloseListenerAction,
   BaseBrowserContext,
   NewWindowOptions,
   MediaMetadata,

--- a/packages/sigil/src/frontend/browser-context.tsx
+++ b/packages/sigil/src/frontend/browser-context.tsx
@@ -53,13 +53,33 @@ export type NewWindowOptions = {
   mode?: string;
 };
 
+export type BrowserCloseListenerAction =
+  | {
+      action: 'allow';
+    }
+  | {
+      action: 'confirm';
+      confirmation: string;
+    };
+
+/**
+ * A listener that can be registered to listen for close events,
+ * and prevent them if needed.
+ *
+ * Note that in browser environments,
+ * preventing close will always display the same confirmation message that a user
+ * can then choose to proceed with or not.
+ */
+export type BrowserCloseListener = () => BrowserCloseListenerAction;
+
 export type BaseBrowserContext = {
   appListenerChangesHandledExternally?: boolean;
   openExternalLink: (url: string) => void;
   openNewWidow: (url: string, options?: NewWindowOptions) => void;
   selectDirectory: (() => Promise<string | null>) | null;
   openDevTools: (() => Promise<null>) | null;
-  confirmClose: (message: string) => void;
+  addCloseListener: (listener: BrowserCloseListener) => void;
+  removeCloseListener: (listener: BrowserCloseListener) => void;
   mediaSession: MediaSessionControl;
 };
 
@@ -68,6 +88,26 @@ export const createDefaultBrowserContext = <
 >(
   browser?: Partial<TBrowserContext> | null,
 ): TBrowserContext => {
+  const closeListeners = new Set<BrowserCloseListener>();
+
+  window.addEventListener('beforeunload', (e) => {
+    let confirm = false;
+    for (const listener of closeListeners) {
+      // In browsers, the message is fixed and cannot be customized,
+      // so we just check if any listener wants to prevent the close action.
+      if (listener().action === 'confirm') {
+        confirm = true;
+      }
+    }
+
+    if (confirm) {
+      // Give message to show confirmation dialog
+      e.preventDefault();
+      e.returnValue = '';
+      return;
+    }
+  });
+
   const defaults: BaseBrowserContext = {
     appListenerChangesHandledExternally: false,
     openExternalLink: (url: string) => {
@@ -78,9 +118,10 @@ export const createDefaultBrowserContext = <
     },
     selectDirectory: null,
     openDevTools: null,
-    confirmClose: () => {
-      // Browsers do not allow custom close confirmation text.
-    },
+    addCloseListener: (listener: BrowserCloseListener) =>
+      closeListeners.add(listener),
+    removeCloseListener: (listener: BrowserCloseListener) =>
+      closeListeners.delete(listener),
     mediaSession: createBrowserMediaSession(),
   };
 


### PR DESCRIPTION
Make it possible for electron apps to block closing windows properly by listening to the `close` event, by introducing a new API for registering window close confirmation behavior.