### PR TITLE
Keep player running when settings/debugger/info opened

### DIFF
--- a/.changeset/fine-states-push.md
+++ b/.changeset/fine-states-push.md
@@ -1,0 +1,11 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Keep player running when settings/debugger/info opened
+
+Previously, when opening any of the other app windows while music was playing,
+the music would stop without any warning. Now it continues playing in the
+background.
+
+fixes 82

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/layout.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/layout.tsx
@@ -94,10 +94,15 @@ export const Layout = <WindowMode extends string>({
               {STRINGS.reconnect}
             </ControlButton>
           </SizeAwareDiv>
-        ) : windowMode && modes?.[windowMode] ? (
-          modes[windowMode].child(setWindowMode)
         ) : (
-          children
+          <>
+            {windowMode && modes?.[windowMode] && (
+              <div className="flex size-full flex-col">
+                {modes[windowMode].child(setWindowMode)}
+              </div>
+            )}
+            {children}
+          </>
         )}
       </div>
       {footer && (


### PR DESCRIPTION
Previously, when opening any of the other app windows while music was playing, the music would stop without any warning. Now it continues playing in the background.

fixes #82