### PR TITLE
Add more config metadata to timecodes UI

### DIFF
--- a/.changeset/sharp-animals-grab.md
+++ b/.changeset/sharp-animals-grab.md
@@ -1,0 +1,17 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Add more config metadata to timecodes UI
+
+- ArtNet & TCNet Inputs now display interface name & IP address
+- ArtNet Outputs now display interface name & IP address, or hostname
+- MIDI Inputs & Outputs now display device type (virtual vs physical)
+  and device name
+- System clock generators now show timezone when it's different to
+  system clock
+
+All this information is displayed at the top of the timecode alongside
+the name. If a name is set, that will be shown first (to the left),
+with the metadata shown after. If no name is set,
+the metadata is shown to the left of the placeholder.

--- a/apps/timecode-toolbox/src/components/frontend/constants.ts
+++ b/apps/timecode-toolbox/src/components/frontend/constants.ts
@@ -82,6 +82,9 @@ export const STRINGS = {
       `Edit ${protocol} Generator ${name}`,
     deleteDialog: `Delete generator?`,
     deleteDialogDetails: `Are you sure you want to delete this generator? This action cannot be undone.`,
+    clock: {
+      systemTimezone: (tz: string) => `Timezone: ${tz}`,
+    },
   },
   outputs: {
     title: 'OUTPUTS',
@@ -132,6 +135,12 @@ export const STRINGS = {
   errors: {
     unknownTimecodeID: 'Unknown timecode ID, please close the window',
   },
+  midi: {
+    deviceLabelForPort: (device: string) => `Device: ${device}`,
+    deviceLabelForVirtual: `VIRTUAL`,
+    deviceTypePort: 'Connected Device',
+    deviceTypeVirtual: 'Arcane Virtual MIDI Device',
+  },
   updates: {
     updateAvailable: (current: string, latest: string) =>
       `Version ${latest} is available! You are currently on version ${current}.`,
@@ -143,5 +152,6 @@ export const STRINGS = {
   general: {
     enabled: 'Enabled',
     disabled: 'Disabled',
+    networkTargetHost: (host: string) => `Host: ${host}`,
   },
 } as const;

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/midi.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/midi.tsx
@@ -12,6 +12,7 @@ import {
   ControlSelect,
 } from '@arcanewizards/sigil/frontend/controls';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
+import { STRINGS } from '../../constants';
 
 type MidiTargetSettingsProps = {
   type: 'input' | 'output';
@@ -84,8 +85,8 @@ export const MidiTargetSettings: FC<MidiTargetSettingsProps> = ({
       <ControlSelect
         value={target.type}
         options={[
-          { value: 'port', label: 'Connected Device' },
-          { value: 'virtual', label: 'Arcane Virtual MIDI Device' },
+          { value: 'port', label: STRINGS.midi.deviceTypePort },
+          { value: 'virtual', label: STRINGS.midi.deviceTypeVirtual },
         ]}
         variant="large"
         position="both"

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -21,6 +21,7 @@ import {
   isGeneratorInstanceId,
   ToolboxConfig,
   UniversalConfig,
+  MidiTargetConfig,
 } from '../../../proto';
 import { displayMillis } from '../util';
 import { StageContext } from '@arcanejs/toolkit-frontend';
@@ -54,6 +55,7 @@ import {
   getTimecodeInstance,
 } from '../../../../util';
 import { LoadFileCallback, WithAudioPlayer } from './audio-player';
+import { useNetworkInterfaceInfo } from '../hooks';
 
 type ActiveTimecodeTextProps = {
   effectiveStartTimeMillis: number;
@@ -584,6 +586,14 @@ export const getLinkedSourceInfo = (
   return info;
 };
 
+/**
+ * Additional labels / metadata that can be displayed on a timecode instance,
+ * such as network information or other config.
+ */
+type TimecodeLabel = {
+  text: string;
+};
+
 type TimecodeTreeDisplayProps = {
   config: UniversalConfig;
   /**
@@ -598,6 +608,7 @@ type TimecodeTreeDisplayProps = {
   rootState: TimecodeDisplayProps['rootState'];
   namePlaceholder: string;
   buttons: ReactNode;
+  labels: TimecodeLabel[];
   /**
    * If set, calling this will assign the instance to the given output on
    */
@@ -637,6 +648,7 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
   rootState,
   namePlaceholder,
   buttons,
+  labels,
   assignToOutput,
   loadFile,
   startPlayer,
@@ -692,6 +704,7 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
         rootState={rootState}
         namePlaceholder={namePlaceholder}
         buttons={buttons}
+        labels={labels}
         assignToOutput={assignToOutput}
         loadFile={loadFile}
         startPlayer={startPlayer}
@@ -722,61 +735,93 @@ export const TimecodeTreeDisplay: FC<TimecodeTreeDisplayProps> = ({
         headerComponents={
           <>
             <div className="flex grow basis-0 items-start gap-0.25">
-              <div className="grow">
-                <div className="flex items-center gap-0.25">
-                  <div
-                    className="
-                      m-0.25 rounded-md border border-sigil-bg-light
-                      bg-timecode-usage-foreground px-1 py-0.25
-                      text-sigil-control text-timecode-usage-text
-                    "
-                  >
-                    {type}
-                  </div>
-                  <div
-                    className={cn(
-                      'w-0 grow truncate p-0.5',
-                      cnd(name.length, 'font-bold', 'italic opacity-50'),
-                    )}
-                  >
-                    {name.length ? name.join(' / ') : namePlaceholder}
-                  </div>
-                </div>
-                {link && (
-                  <div
-                    className="
-                      flex items-center gap-0.25 text-timecode-usage-foreground
-                    "
-                    style={cssSigilColorUsageVariables(
-                      'timecode-usage',
-                      // Override timecode color with the user hint preferences
-                      // when no color is specified
-                      // as that will be what's used by the linked input/generator
-                      sigilColorUsage(link.color ?? 'hint'),
-                    )}
-                  >
-                    <div
+              <div className="relative grow">
+                <div className="absolute inset-x-0 top-0">
+                  <div className="flex items-center gap-0.25 truncate">
+                    <span
                       className="
-                        m-0.25 flex items-center gap-0.25 rounded-md border
-                        border-sigil-bg-light bg-timecode-usage-foreground px-1
-                        py-0.25 text-sigil-control text-timecode-usage-text
+                        m-0.25 rounded-md border border-sigil-bg-light
+                        bg-timecode-usage-foreground px-1 py-0.25
+                        text-sigil-control text-timecode-usage-text
                       "
                     >
-                      <Icon icon="link" className="text-[120%]" />
-                      <span>{link.type}</span>
-                    </div>
+                      {type}
+                    </span>
+                    {name.length ? (
+                      <TooltipWrapper tooltip={name.join(' / ')}>
+                        <span className="truncate p-0.5 font-bold">
+                          {name.join(' / ')}
+                        </span>
+                      </TooltipWrapper>
+                    ) : null}
+                    {labels.map((label, index) => (
+                      <TooltipWrapper key={index} tooltip={label.text}>
+                        <span
+                          key={index}
+                          className="
+                            m-0.25 truncate rounded-md border
+                            border-sigil-bg-light bg-sigil-foreground-muted px-1
+                            py-0.25 text-sigil-control text-sigil-bg-dark
+                          "
+                        >
+                          {label.text}
+                        </span>
+                      </TooltipWrapper>
+                    ))}
+                    {!name.length && (
+                      <TooltipWrapper tooltip={namePlaceholder}>
+                        <span
+                          className="
+                            grow basis-0 truncate p-0.5 italic opacity-50
+                          "
+                        >
+                          {namePlaceholder}
+                        </span>
+                      </TooltipWrapper>
+                    )}
+                  </div>
+                  {link && (
                     <div
-                      className={cn(
-                        'w-0 grow truncate p-0.5',
-                        cnd(link.name.length, 'font-bold', 'italic opacity-50'),
+                      className="
+                        flex items-center gap-0.25
+                        text-timecode-usage-foreground
+                      "
+                      style={cssSigilColorUsageVariables(
+                        'timecode-usage',
+                        // Override timecode color with the user hint preferences
+                        // when no color is specified
+                        // as that will be what's used by the linked input/generator
+                        sigilColorUsage(link.color ?? 'hint'),
                       )}
                     >
-                      {link.name.length
-                        ? link.name.join(' / ')
-                        : link.namePlaceholder}
+                      <div
+                        className="
+                          m-0.25 flex items-center gap-0.25 rounded-md border
+                          border-sigil-bg-light bg-timecode-usage-foreground
+                          px-1 py-0.25 text-sigil-control
+                          text-timecode-usage-text
+                        "
+                      >
+                        <Icon icon="link" className="text-[120%]" />
+                        <span>{link.type}</span>
+                      </div>
+                      <div
+                        className={cn(
+                          'w-0 grow truncate p-0.5',
+                          cnd(
+                            link.name.length,
+                            'font-bold',
+                            'italic opacity-50',
+                          ),
+                        )}
+                      >
+                        {link.name.length
+                          ? link.name.join(' / ')
+                          : link.namePlaceholder}
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </div>
             <ControlButtonGroup className="rounded-md bg-sigil-bg-light">
@@ -824,6 +869,109 @@ type FullscreenTimecodeConfig = {
   disabled: boolean;
 };
 
+const labelForMidiTarget = (target: MidiTargetConfig): TimecodeLabel => ({
+  text:
+    target.type === 'virtual'
+      ? STRINGS.midi.deviceLabelForVirtual
+      : STRINGS.midi.deviceLabelForPort(target.deviceName),
+});
+
+export const useTimecodeLabels = (id: TimecodeInstanceId): TimecodeLabel[] => {
+  const { config } = useContext(ConfigContext);
+
+  const iface = useMemo<string | null>(() => {
+    if (isInputInstanceId(id)) {
+      const c = config.inputs[id[1]];
+      if (!c) {
+        return null;
+      }
+      if (c.definition.type === 'artnet' || c.definition.type === 'tcnet') {
+        return c.definition.iface;
+      }
+    } else if (isOutputInstanceId(id)) {
+      const c = config.outputs[id[1]];
+      if (!c) {
+        return null;
+      }
+      if (
+        c.definition.type === 'artnet' &&
+        c.definition.target.type === 'interface'
+      ) {
+        return c.definition.target.interface;
+      }
+      return null;
+    }
+    return null;
+  }, [id, config]);
+
+  const ifaceInfo = useNetworkInterfaceInfo(iface);
+
+  const extraLabels = useMemo<TimecodeLabel[]>(() => {
+    if (isInputInstanceId(id)) {
+      const c = config.inputs[id[1]];
+      if (!c) {
+        return [];
+      }
+      if (c.definition.type === 'midi') {
+        return [labelForMidiTarget(c.definition.target)];
+      }
+      return [];
+    } else if (isGeneratorInstanceId(id)) {
+      const c = config.generators[id[1]];
+      if (!c) {
+        return [];
+      }
+      if (
+        c.definition.type === 'clock' &&
+        c.definition.mode === 'system' &&
+        c.definition.timezone
+      ) {
+        return [
+          {
+            text: STRINGS.generators.clock.systemTimezone(
+              c.definition.timezone,
+            ),
+          },
+        ];
+      }
+      return [];
+    } else {
+      const c = config.outputs[id[1]];
+      if (!c) {
+        return [];
+      }
+      if (c.definition.type === 'midi') {
+        return [labelForMidiTarget(c.definition.target)];
+      }
+      if (
+        c.definition.type === 'artnet' &&
+        c.definition.target.type === 'host'
+      ) {
+        return [
+          {
+            text: STRINGS.general.networkTargetHost(c.definition.target.host),
+          },
+        ];
+      }
+      return [];
+    }
+  }, [id, config]);
+
+  return useMemo(
+    () => [
+      ...(ifaceInfo
+        ? [
+            {
+              text: `${ifaceInfo.name} (${ifaceInfo.address})`,
+            },
+          ]
+        : []),
+      ...extraLabels,
+    ],
+    [ifaceInfo, extraLabels],
+  );
+};
+
 export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
   id,
 }) => {
@@ -864,6 +1012,8 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
     }
     return null;
   }, [id, config.generators]);
+
+  const labels = useTimecodeLabels(id);
 
   const instanceConfig: FullscreenTimecodeConfig | null = useMemo(() => {
     if (isInputInstanceId(id)) {
@@ -962,6 +1112,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
               }}
               assignToOutput={null}
               buttons={null}
+              labels={labels}
               link={linkedSourceInfo}
               loadFile={loadFile}
               startPlayer={startPlayer}
@@ -976,6 +1127,7 @@ export const FullscreenTimecodeDisplay: FC<{ id: TimecodeInstanceId }> = ({
           rootState={rootState}
           assignToOutput={null}
           buttons={null}
+          labels={labels}
           link={linkedSourceInfo}
           loadFile={null}
           startPlayer={null}

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
@@ -25,6 +25,7 @@ import {
   GeneratorClockDefinition,
   GeneratorConfig,
   GeneratorDefinition,
+  TimecodeInstanceId,
   ToolboxRootGetTimezoneInfoReturn,
 } from '../../proto';
 import { v4 as uuidv4 } from 'uuid';
@@ -35,6 +36,7 @@ import {
 import {
   TimecodeDisplayProps,
   TimecodeTreeDisplay,
+  useTimecodeLabels,
 } from './core/timecode-display';
 import { WithAudioPlayer } from './core/audio-player';
 
@@ -385,9 +387,12 @@ const GeneratorDisplay: FC<GeneratorDisplayProps> = ({
     [state?.errors, state?.warnings, additionalErrors],
   );
 
+  const id: TimecodeInstanceId = useMemo(() => ['generator', uuid], [uuid]);
+  const labels = useTimecodeLabels(id);
+
   return (
     <TimecodeTreeDisplay
-      id={['generator', uuid]}
+      id={id}
       config={{ delayMs: config.delayMs ?? null }}
       type={STRINGS.generators.type[config.definition.type]}
       name={config.name ? [config.name] : []}
@@ -415,6 +420,7 @@ const GeneratorDisplay: FC<GeneratorDisplayProps> = ({
           />
         </>
       }
+      labels={labels}
       assignToOutput={assignToOutput}
     />
   );

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/hooks.ts
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/hooks.ts
@@ -1,5 +1,7 @@
 import { useBrowserContext } from '@arcanewizards/sigil/frontend';
-import { useCallback } from 'react';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { SystemContext } from './context';
+import { ToolboxRootGetNetworkInterfacesReturn } from '../../proto';
 
 type ResolvedFile =
   | {
@@ -35,4 +37,46 @@ export const useFileResolver = () => {
     },
     [getPathForFile],
   );
+};
+
+export const useNetworkInterfaces = (initialFetch: boolean = true) => {
+  const { getNetworkInterfaces } = useContext(SystemContext);
+  const [interfaces, setInterfaces] =
+    useState<ToolboxRootGetNetworkInterfacesReturn | null>(null);
+
+  const refreshInterfaces = useCallback(() => {
+    setInterfaces(null);
+    getNetworkInterfaces().then((ifs) => setInterfaces(ifs));
+  }, [getNetworkInterfaces]);
+
+  useEffect(() => {
+    if (initialFetch) {
+      refreshInterfaces();
+    }
+  }, [refreshInterfaces, initialFetch]);
+
+  return { interfaces, refreshInterfaces };
+};
+
+export const useNetworkInterfaceInfo = (iface: string | null) => {
+  /**
+   * Don't auto-fetch, only fetch when iface is not null
+   */
+  const { interfaces, refreshInterfaces } = useNetworkInterfaces(false);
+
+  const interfacesRef = useRef(interfaces);
+
+  useEffect(() => {
+    interfacesRef.current = interfaces;
+  }, [interfaces]);
+
+  useEffect(() => {
+    // If we aren't aware of the current interface, refresh the list
+    // (only once per interface change, to avoid infinite loops).
+    if (iface && !interfacesRef.current?.[iface]) {
+      refreshInterfaces();
+    }
+  }, [iface, refreshInterfaces]);
+
+  return (iface && interfaces?.[iface]) || null;
 };

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
@@ -1,14 +1,7 @@
-import {
-  FC,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { FC, useCallback, useContext, useMemo, useState } from 'react';
 import { STRINGS } from '../constants';
 import { PrimaryToolboxSection } from './util';
-import { ConfigContext, SystemContext, useApplicationState } from './context';
+import { ConfigContext, useApplicationState } from './context';
 import {
   ControlButton,
   ControlColorSelect,
@@ -23,7 +16,7 @@ import {
   InputConfig,
   InputDefinition,
   MidiTargetConfig,
-  ToolboxRootGetNetworkInterfacesReturn,
+  TimecodeInstanceId,
 } from '../../proto';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import { ARTNET_PORT } from '@arcanewizards/artnet/constants';
@@ -33,27 +26,21 @@ import {
   ChangeCommitContext,
   useChangeCommitBoundary,
 } from '@arcanewizards/sigil/frontend/context';
-import { TimecodeTreeDisplay } from './core/timecode-display';
+import {
+  TimecodeTreeDisplay,
+  useTimecodeLabels,
+} from './core/timecode-display';
 import { NoToolboxChildren } from './content';
 import { MidiTargetSettings } from './core/midi';
+import { useNetworkInterfaces } from './hooks';
 
 const DmxConnectionSettings: FC<SettingsProps<InputDefinition>> = ({
   data,
   updateSettings,
 }) => {
   const { commitChanges } = useContext(ChangeCommitContext);
-  const { getNetworkInterfaces } = useContext(SystemContext);
-  const [interfaces, setInterfaces] =
-    useState<ToolboxRootGetNetworkInterfacesReturn | null>(null);
 
-  const refreshInterfaces = useCallback(() => {
-    setInterfaces(null);
-    getNetworkInterfaces().then((ifs) => setInterfaces(ifs));
-  }, [getNetworkInterfaces]);
-
-  useEffect(() => {
-    refreshInterfaces();
-  }, [refreshInterfaces]);
+  const { interfaces, refreshInterfaces } = useNetworkInterfaces();
 
   if (data.type !== 'artnet') {
     return null;
@@ -120,18 +107,7 @@ const TCNetConnectionSettings: FC<SettingsProps<InputDefinition>> = ({
   data,
   updateSettings,
 }) => {
-  const { getNetworkInterfaces } = useContext(SystemContext);
-  const [interfaces, setInterfaces] =
-    useState<ToolboxRootGetNetworkInterfacesReturn | null>(null);
-
-  const refreshInterfaces = useCallback(() => {
-    setInterfaces(null);
-    getNetworkInterfaces().then((ifs) => setInterfaces(ifs));
-  }, [getNetworkInterfaces]);
-
-  useEffect(() => {
-    refreshInterfaces();
-  }, [refreshInterfaces]);
+  const { interfaces, refreshInterfaces } = useNetworkInterfaces();
 
   if (data.type !== 'tcnet') {
     return null;
@@ -463,9 +439,12 @@ export const InputDisplay: FC<InputDisplayProps> = ({
     [state?.errors, state?.warnings],
   );
 
+  const id: TimecodeInstanceId = useMemo(() => ['input', uuid], [uuid]);
+  const labels = useTimecodeLabels(id);
+
   return (
     <TimecodeTreeDisplay
-      id={['input', uuid]}
+      id={id}
       config={{ delayMs: config.delayMs ?? null }}
       type={STRINGS.protocols[config.definition.type].short}
       name={config.name ? [config.name] : []}
@@ -498,6 +477,7 @@ export const InputDisplay: FC<InputDisplayProps> = ({
           />
         </>
       }
+      labels={labels}
       assignToOutput={assignToOutput}
     />
   );

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -4,7 +4,6 @@ import {
   SetStateAction,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -20,19 +19,20 @@ import {
   ControlLabel,
   ControlSelect,
 } from '@arcanewizards/sigil/frontend/controls';
-import { ConfigContext, SystemContext, useApplicationState } from './context';
+import { ConfigContext, useApplicationState } from './context';
 import {
   OutputArtnetDefinition,
   OutputConfig,
   OutputDefinition,
   OutputMidiDefinition,
   TimecodeInstance,
-  ToolboxRootGetNetworkInterfacesReturn,
+  TimecodeInstanceId,
 } from '../../proto';
 import {
   getLinkedSourceInfo,
   LinkedSourceInfo,
   TimecodeTreeDisplay,
+  useTimecodeLabels,
 } from './core/timecode-display';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import {
@@ -54,24 +54,15 @@ import {
 } from '../../../util';
 import { NoToolboxChildren } from './content';
 import { MidiTargetSettings } from './core/midi';
+import { useNetworkInterfaces } from './hooks';
 
 const DmxConnectionSettings: FC<SettingsProps<OutputDefinition>> = ({
   data,
   updateSettings,
 }) => {
   const { commitChanges } = useContext(ChangeCommitContext);
-  const { getNetworkInterfaces } = useContext(SystemContext);
-  const [interfaces, setInterfaces] =
-    useState<ToolboxRootGetNetworkInterfacesReturn | null>(null);
 
-  const refreshInterfaces = useCallback(() => {
-    setInterfaces(null);
-    getNetworkInterfaces().then((ifs) => setInterfaces(ifs));
-  }, [getNetworkInterfaces]);
-
-  useEffect(() => {
-    refreshInterfaces();
-  }, [refreshInterfaces]);
+  const { interfaces, refreshInterfaces } = useNetworkInterfaces();
 
   const updateArtnetSettings = useCallback(
     (change: (current: OutputArtnetDefinition) => OutputArtnetDefinition) => {
@@ -560,6 +551,9 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
     [applicationState.outputs, uuid],
   );
 
+  const id: TimecodeInstanceId = useMemo(() => ['output', uuid], [uuid]);
+  const labels = useTimecodeLabels(id);
+
   return (
     <div
       className="relative flex flex-col"
@@ -572,7 +566,7 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
       }
     >
       <TimecodeTreeDisplay
-        id={['output', uuid]}
+        id={id}
         config={{ delayMs: config.delayMs ?? null }}
         assignToOutput={null}
         type={STRINGS.protocols[config.definition.type].short}
@@ -616,6 +610,7 @@ const OutputDisplay: FC<OutputDisplayProps> = ({
             />
           </>
         }
+        labels={labels}
       />
       {assignToOutput === uuid && config.link && (
         <SizeAwareDiv className="absolute inset-0" onClick={clearLink}>

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/settings.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/settings.tsx
@@ -24,13 +24,13 @@ import {
   ToolbarWrapper,
 } from '@arcanewizards/sigil/frontend/toolbars';
 import { STRINGS } from '../constants';
-import { ConfigContext, SystemContext, useApplicationState } from './context';
-import { ToolboxRootGetNetworkInterfacesReturn } from '../../proto';
+import { ConfigContext, useApplicationState } from './context';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import { cn } from '@arcanejs/toolkit-frontend/util';
 import { useBrowserContext } from '@arcanewizards/sigil/frontend';
 import { ListenerConfig } from '@arcanewizards/sigil';
 import { portString } from '@arcanewizards/sigil/shared/config';
+import { useNetworkInterfaces } from './hooks';
 
 type SettingsProps = {
   setWindowMode: (mode: null) => void;
@@ -48,18 +48,7 @@ const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
 type InterfaceChoice = 'any' | `specific:${string}`;
 
 const AppPortConfig: FC = () => {
-  const { getNetworkInterfaces } = useContext(SystemContext);
-  const [interfaces, setInterfaces] =
-    useState<ToolboxRootGetNetworkInterfacesReturn | null>(null);
-
-  const refreshInterfaces = useCallback(() => {
-    setInterfaces(null);
-    getNetworkInterfaces().then((ifs) => setInterfaces(ifs));
-  }, [getNetworkInterfaces]);
-
-  useEffect(() => {
-    refreshInterfaces();
-  }, [refreshInterfaces]);
+  const { interfaces, refreshInterfaces } = useNetworkInterfaces();
 
   const { appListenerChangesHandledExternally } = useBrowserContext();
 


### PR DESCRIPTION
- ArtNet & TCNet Inputs now display interface name & IP address
- ArtNet Outputs now display interface name & IP address, or hostname
- MIDI Inputs & Outputs now display device type (virtual vs physical) and device name
- System clock generators now show timezone when it's different to system clock

All this information is displayed at the top of the timecode alongside the name. If a name is set, that will be shown first (to the left), with the metadata shown after. If no name is set,
the metadata is shown to the left of the placeholder.

fixes #105