### PR TITLE
Improve usability of Delay config

### DIFF
--- a/.changeset/smart-ties-hope.md
+++ b/.changeset/smart-ties-hope.md
@@ -1,0 +1,8 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Some minor updates to ControlInput & InputWithDelayedPropagation
+
+- Introduce a hasError property on ControlInput
+- Allow Esc key to reset value to last value provided by the prop

--- a/.changeset/stale-lights-film.md
+++ b/.changeset/stale-lights-film.md
@@ -1,0 +1,13 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Improve usability of Delay config
+
+- Make it clear that delay field can also be used for an offset
+- Highlight either Offset or Delay, depending on whether the value is negative
+  or positive.
+- Allow users to enter offsets/delays using a timecode format,
+  and display this by default in the config options
+
+fixes #78

--- a/apps/timecode-toolbox/src/components/frontend/constants.ts
+++ b/apps/timecode-toolbox/src/components/frontend/constants.ts
@@ -67,7 +67,12 @@ export const STRINGS = {
   },
   accuracy: (accuracyMillis: number) =>
     `Accuracy: ${MS_FORMAT.format(accuracyMillis)}`,
-  delay: (delay: string) => `Delay: ${delay}`,
+  delay: {
+    delayLabel: 'Delay',
+    offsetLabel: 'Offset',
+    delayDescription:
+      'Enter a positive number for an offset, or a negative number for a delay.',
+  },
   generators: {
     title: 'GENERATORS',
     unnamed: 'Unnamed Generator',

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/delay.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/delay.tsx
@@ -1,0 +1,108 @@
+import {
+  ControlInput,
+  ControlLabel,
+  ControlParagraph,
+} from '@arcanewizards/sigil/frontend/controls';
+
+import { FC, useCallback, useState } from 'react';
+import { STRINGS } from '../../constants';
+import { cnd } from '@arcanewizards/sigil/frontend/styling';
+import { displayMillis } from '../util';
+import { cn } from '@arcanejs/toolkit-frontend/util';
+
+type DelayConfigProps = {
+  delayMs: number | undefined;
+  commitChanges: () => void;
+  updateDelay: (delayMs: number | undefined) => void;
+};
+
+const PLACEHOLDER = `e.g: ${displayMillis(600_000)}`;
+
+const NUMBER_REGEX = /^\d+$/;
+
+const parseTimecode = (value: string): number | null => {
+  value = value.trim();
+  if (value.length === 0) {
+    return 0;
+  }
+  const isNegative = value.startsWith('-');
+  const normalizedValue = isNegative ? value.slice(1) : value;
+  const parts = normalizedValue.split(':').map((part) => part.trim());
+  if (parts.length === 0 || parts.length > 4) {
+    return null;
+  }
+
+  const partNumbers = parts.map((part) =>
+    NUMBER_REGEX.test(part) ? parseInt(part) : NaN,
+  );
+  if (partNumbers.some((num) => isNaN(num))) {
+    return null;
+  }
+
+  const hours = partNumbers.length === 4 ? partNumbers[0]! : 0;
+  const minutes =
+    partNumbers.length >= 3 ? partNumbers[partNumbers.length - 3]! : 0;
+  const seconds =
+    partNumbers.length >= 2 ? partNumbers[partNumbers.length - 2]! : 0;
+  const millis = partNumbers[partNumbers.length - 1]!;
+
+  const totalMillis = ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis;
+  return isNegative ? -totalMillis : totalMillis;
+};
+
+export const DelayConfig: FC<DelayConfigProps> = ({
+  delayMs,
+  commitChanges,
+  updateDelay,
+}) => {
+  const [hasError, setHasError] = useState(false);
+
+  const handleChange = useCallback(
+    (value: string, enterPressed: boolean) => {
+      const parsed = parseTimecode(value);
+      if (parsed === null) {
+        setHasError(true);
+        return;
+      }
+      setHasError(false);
+      updateDelay(-parsed);
+      if (enterPressed) {
+        commitChanges();
+      }
+    },
+    [updateDelay, commitChanges],
+  );
+
+  return (
+    <>
+      <ControlLabel>
+        <span
+          className={cn(
+            cnd(delayMs && delayMs < 0, 'line-through opacity-50', 'font-bold'),
+          )}
+        >
+          {STRINGS.delay.delayLabel}
+        </span>
+        {' / '}
+        <span
+          className={cn(
+            cnd(delayMs && delayMs > 0, 'line-through opacity-50', 'font-bold'),
+          )}
+        >
+          {STRINGS.delay.offsetLabel}
+        </span>
+      </ControlLabel>
+      <ControlInput
+        position="both"
+        type="string"
+        value={delayMs ? displayMillis(-delayMs) : ''}
+        placeholder={PLACEHOLDER}
+        onChange={handleChange}
+        hasError={hasError}
+      />
+      <ControlParagraph position="both">
+        {STRINGS.delay.delayDescription}
+      </ControlParagraph>
+    </>
+  );
+};

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/core/timecode-display.tsx
@@ -461,11 +461,36 @@ const TimecodeDisplay: FC<TimecodeDisplayProps> = ({
         state.accuracyMillis !== null ||
         (config.delayMs !== null && config.delayMs !== undefined)) && (
         <div className="flex gap-px">
-          {config.delayMs !== null && config.delayMs !== undefined && (
-            <div className="grow basis-0 truncate bg-sigil-bg-light p-0.5">
-              {STRINGS.delay(displayMillis(config.delayMs))}
-            </div>
-          )}
+          {config.delayMs !== null &&
+            config.delayMs !== undefined &&
+            config.delayMs !== 0 && (
+              <div className="grow basis-0 truncate bg-sigil-bg-light p-0.5">
+                <span
+                  className={cn(
+                    cnd(
+                      config.delayMs < 0,
+                      'line-through opacity-50',
+                      'font-bold',
+                    ),
+                  )}
+                >
+                  {STRINGS.delay.delayLabel}
+                </span>
+                {' / '}
+                <span
+                  className={cn(
+                    cnd(
+                      config.delayMs > 0,
+                      'line-through opacity-50',
+                      'font-bold',
+                    ),
+                  )}
+                >
+                  {STRINGS.delay.offsetLabel}
+                </span>
+                {`: ${displayMillis(Math.abs(config.delayMs))}`}
+              </div>
+            )}
           {state.smpteMode !== null && (
             <div className="grow basis-0 truncate bg-sigil-bg-light p-0.5">
               {STRINGS.smtpeModes[state.smpteMode]}

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/generators.tsx
@@ -39,6 +39,7 @@ import {
   useTimecodeLabels,
 } from './core/timecode-display';
 import { WithAudioPlayer } from './core/audio-player';
+import { DelayConfig } from './core/delay';
 
 const CLOCK_MODE_OPTIONS: Array<
   SelectOption<GeneratorClockDefinition['mode']>
@@ -303,24 +304,14 @@ export const GeneratorSettingsDialog: FC<GeneratorSettingsDialogProps> = ({
           />
         ) : null}
 
-        <ControlLabel>Delay (ms)</ControlLabel>
-        <ControlInput
-          position="both"
-          type="string"
-          value={data.delayMs?.toString() ?? ''}
-          placeholder={`Default (0ms)`}
-          onChange={(value, enterPressed) => {
-            const delayMs = value ? parseInt(value, 10) : undefined;
-            if (delayMs !== undefined && isNaN(delayMs)) {
-              return;
-            }
+        <DelayConfig
+          delayMs={data.delayMs}
+          commitChanges={commitChanges}
+          updateDelay={(delayMs) => {
             updateSettings((current) => ({
               ...current,
               delayMs,
             }));
-            if (enterPressed) {
-              commitChanges();
-            }
           }}
         />
         {target.type === 'add' ? (

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/inputs.tsx
@@ -33,6 +33,7 @@ import {
 import { NoToolboxChildren } from './content';
 import { MidiTargetSettings } from './core/midi';
 import { useNetworkInterfaces } from './hooks';
+import { DelayConfig } from './core/delay';
 
 const DmxConnectionSettings: FC<SettingsProps<InputDefinition>> = ({
   data,
@@ -343,24 +344,15 @@ export const InputSettingsDialog: FC<InputSettingsDialogProps> = ({
             updateSettings={updateDefinition}
           />
         ) : null}
-        <ControlLabel>Delay (ms)</ControlLabel>
-        <ControlInput
-          position="both"
-          type="string"
-          value={data.delayMs?.toString() ?? ''}
-          placeholder={`Default (0ms)`}
-          onChange={(value, enterPressed) => {
-            const delayMs = value ? parseInt(value, 10) : undefined;
-            if (delayMs !== undefined && isNaN(delayMs)) {
-              return;
-            }
+
+        <DelayConfig
+          delayMs={data.delayMs}
+          commitChanges={commitChanges}
+          updateDelay={(delayMs) => {
             updateSettings((current) => ({
               ...current,
               delayMs,
             }));
-            if (enterPressed) {
-              commitChanges();
-            }
           }}
         />
         {target.type === 'add' ? (

--- a/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
+++ b/apps/timecode-toolbox/src/components/frontend/toolbox/outputs.tsx
@@ -55,6 +55,7 @@ import {
 import { NoToolboxChildren } from './content';
 import { MidiTargetSettings } from './core/midi';
 import { useNetworkInterfaces } from './hooks';
+import { DelayConfig } from './core/delay';
 
 const DmxConnectionSettings: FC<SettingsProps<OutputDefinition>> = ({
   data,
@@ -417,24 +418,15 @@ export const OutputSettingsDialog: FC<OutputSettingsDialogProps> = ({
             updateSettings={updateDefinition}
           />
         ) : null}
-        <ControlLabel>Delay (ms)</ControlLabel>
-        <ControlInput
-          position="both"
-          type="string"
-          value={data.delayMs?.toString() ?? ''}
-          placeholder={`Default (0ms)`}
-          onChange={(value, enterPressed) => {
-            const delayMs = value ? parseInt(value, 10) : undefined;
-            if (delayMs !== undefined && isNaN(delayMs)) {
-              return;
-            }
+
+        <DelayConfig
+          delayMs={data.delayMs}
+          commitChanges={commitChanges}
+          updateDelay={(delayMs) => {
             updateSettings((current) => ({
               ...current,
               delayMs,
             }));
-            if (enterPressed) {
-              commitChanges();
-            }
           }}
         />
         {target.type === 'add' ? (

--- a/packages/sigil/src/frontend/controls/input.tsx
+++ b/packages/sigil/src/frontend/controls/input.tsx
@@ -74,6 +74,13 @@ export const InputWithDelayedPropagation: FC<InputProps> = ({
       ) {
         onChange(e.currentTarget.value, true);
       }
+      if (e.key === 'Escape' && inputRef.current) {
+        if (inputRef.current.value !== (lastValue.current ?? '')) {
+          // Cancel propagation of the change and reset to the last value
+          e.stopPropagation();
+          inputRef.current.value = lastValue.current ?? '';
+        }
+      }
       onKeyUpProp?.(e);
     },
     [onChange, onKeyUpProp],
@@ -97,6 +104,7 @@ export type ControlInputProps = ComponentProps<
   position?: ControlPosition;
   subgrid?: boolean;
   nonMicro?: boolean;
+  hasError?: boolean;
 };
 
 export const ControlInput: FC<ControlInputProps> = ({
@@ -104,6 +112,7 @@ export const ControlInput: FC<ControlInputProps> = ({
   nonMicro,
   position = 'first',
   subgrid,
+  hasError,
   ...props
 }) => (
   <InputWithDelayedPropagation
@@ -124,6 +133,13 @@ export const ControlInput: FC<ControlInputProps> = ({
       clsControlPosition(position),
       clsControlSubgridPosition(position, subgrid),
       cnd(nonMicro, 'max-[550px]:hidden'),
+      cnd(
+        hasError,
+        `
+          border-2 border-sigil-error-foreground px-[7px]!
+          py-arcane-slider-input-px text-sigil-error-foreground
+        `,
+      ),
       className,
     )}
   />


### PR DESCRIPTION
- Make it clear that delay field can also be used for an offset
- Allow users to enter offsets/delays using a timecode format, and display this by default in the config options
- Allow users to enter offsets/delays using a timecode format, and display this by default in the config options

fixes #78