### PR TITLE
Fix the version of timecode-toolbox-desktop

### DIFF
--- a/apps/timecode-toolbox-desktop/package.json
+++ b/apps/timecode-toolbox-desktop/package.json
@@ -3,7 +3,7 @@
   "productName": "Timecode Toolbox Desktop",
   "description": "Monitor, generate and convert timecodes easily",
   "author": "Arcane Wizards Ltd.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "main": "dist/main.js",
   "repository": {


### PR DESCRIPTION
Following the partially failed CI and published apps, this addresses the incorrectly manually version-bumped packages.