### PR TITLE
Fix warnings re: trackId, and extend mixer data

### DIFF
--- a/.changeset/sunny-lions-grin.md
+++ b/.changeset/sunny-lions-grin.md
@@ -1,0 +1,9 @@
+---
+'@arcanewizards/tcnet': patch
+---
+
+Add support for mixer fader, trim and crossfade values
+
+Latest version of ShowKontrol (v26.5.12) is now correctly outputting mixer
+fader values, along with trim and crossfader assignment.
+This data is now all parsed and added to the interface for client consumption.

--- a/.changeset/ten-singers-knock.md
+++ b/.changeset/ten-singers-knock.md
@@ -1,0 +1,10 @@
+---
+'@arcanewizards/tcnet': patch
+---
+
+Stop printing warnings for supplied trackId
+
+Newer versions of ShowKontrol are correctly supplying trackId information
+within METADATA packets,
+so when they are provided, they can be used directly instead of weighting the
+responses based on which track IDs we think are loaded.

--- a/packages/tcnet/src/monitor.ts
+++ b/packages/tcnet/src/monitor.ts
@@ -7,7 +7,6 @@ import {
   TCNetTimePacketLayer,
 } from './protocol.js';
 import { calculateUniqueNodeId, differsByMoreThan } from './utils.js';
-import { TCNetProtocolError } from './errors.js';
 
 /**
  * How many milliseconds need to have changed to consider a timecode update
@@ -141,6 +140,11 @@ export const createTCNetTimecodeMonitor = (
 
   interface WeightedTrackInfo {
     /**
+     * True if the trackId was included in the METADATA packet,
+     * and so we can be sure this is correct and ignore other track infos.
+     */
+    definitive: boolean;
+    /**
      * How many times have we received this info for this track?
      * We use this to weight the results,
      * as the first result is often incorrect.
@@ -246,7 +250,13 @@ export const createTCNetTimecodeMonitor = (
     let bestMatch: WeightedTrackInfo | null = null;
     for (const info of trackInfoForTrack.values()) {
       const bestMatchCount = bestMatch?.matchCount ?? 0;
+      if (!bestMatch?.definitive && info.definitive) {
+        // We've already seen a definitive match, so we can ignore this one
+        continue;
+      }
       if (
+        // This is the only definitive match we've seen, so it's the best match
+        (info.definitive && !bestMatch?.definitive) ||
         // Best match if we've seen this track the most times
         info.matchCount > bestMatchCount ||
         // Or if we've seen it aa similar same amount of times,
@@ -373,13 +383,6 @@ export const createTCNetTimecodeMonitor = (
   tcNetNode.on('data', ({ packet, node }) => {
     const nodeState = getNodeState(node);
     if (packet.dataType === 'METADATA') {
-      if (packet.trackId) {
-        logger.warn(
-          new TCNetProtocolError(
-            `Received unexpected trackId in METADATA packet, implementation needs to be updated to handle this!`,
-          ),
-        );
-      }
       const info = {
         title: packet.trackTitle || null,
         artist: packet.trackArtist || null,
@@ -389,9 +392,9 @@ export const createTCNetTimecodeMonitor = (
         // quite common with ShowKontrol
         return;
       }
-      const trackID = nodeState.getLayerInfo(
-        layerDataIdToIndex(packet.layer),
-      )?.trackId;
+      const trackID =
+        packet.trackId ??
+        nodeState.getLayerInfo(layerDataIdToIndex(packet.layer))?.trackId;
       if (typeof trackID !== 'number') {
         return;
       }
@@ -402,6 +405,7 @@ export const createTCNetTimecodeMonitor = (
       }
       const key = `${info.artist} - ${info.title}`;
       const weightedInfo: WeightedTrackInfo = trackInfoForTrack.get(key) || {
+        definitive: !!packet.trackId,
         matchCount: 0,
         lastMatchTime: Date.now(),
         info,

--- a/packages/tcnet/src/protocol.ts
+++ b/packages/tcnet/src/protocol.ts
@@ -83,6 +83,36 @@ export const getTcNetMixerType = (id: number): TCNetMixerType => {
   return type;
 };
 
+const TCNET_MIXER_CROSSFADER_ASSIGN_IDS = Object.freeze({
+  THRU: 0,
+  A: 1,
+  B: 2,
+});
+
+export type TCNetMixerCrossfaderAssign =
+  keyof typeof TCNET_MIXER_CROSSFADER_ASSIGN_IDS;
+
+const TCNET_MIXER_CROSSFADER_ASSIGNS = Object.freeze(
+  Object.fromEntries(
+    Object.entries(TCNET_MIXER_CROSSFADER_ASSIGN_IDS).map(([key, value]) => [
+      value,
+      key as unknown as TCNetMixerCrossfaderAssign,
+    ]),
+  ) as Record<number, TCNetMixerCrossfaderAssign>,
+);
+
+export const getTcNetMixerCrossfaderAssign = (
+  id: number,
+): TCNetMixerCrossfaderAssign => {
+  const assign = TCNET_MIXER_CROSSFADER_ASSIGNS[id];
+  if (!assign) {
+    throw new TCNetProtocolError(
+      `Unknown TCNet mixer crossfader assign: ${id}`,
+    );
+  }
+  return assign;
+};
+
 const TCNET_MESSAGE_TYPE_IDS = Object.freeze({
   OPT_IN: 2,
   OPT_OUT: 3,
@@ -572,6 +602,12 @@ const parseMetadataDataPacket = (
   };
 };
 
+export type TCNetMixerDataPacketChannel = {
+  faderLevel: number;
+  trimLevel: number;
+  crossfaderAssign: TCNetMixerCrossfaderAssign;
+};
+
 export type TCNetMixerDataPacket = TCNetDataPacket<'MIXER_DATA'> & {
   mixerId: number;
   mixerType: TCNetMixerType;
@@ -580,6 +616,15 @@ export type TCNetMixerDataPacket = TCNetDataPacket<'MIXER_DATA'> & {
   micEqLow: number;
   masterAudioLevel: number;
   masterFaderLevel: number;
+  channels: [
+    TCNetMixerDataPacketChannel,
+    TCNetMixerDataPacketChannel,
+    TCNetMixerDataPacketChannel,
+    TCNetMixerDataPacketChannel,
+    TCNetMixerDataPacketChannel,
+    TCNetMixerDataPacketChannel,
+  ];
+
   // TODO: Implement the rest, however most of it does not seem to be
   // implemented by The Bridge or ShowKontrol
 };
@@ -599,6 +644,38 @@ const parseMixerDataPacket = (
     micEqLow: buffer.readUInt8(60),
     masterAudioLevel: buffer.readUInt8(61),
     masterFaderLevel: buffer.readUInt8(62),
+    channels: [
+      {
+        faderLevel: buffer.readUInt8(127),
+        trimLevel: buffer.readUInt8(128),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(138)),
+      },
+      {
+        faderLevel: buffer.readUInt8(151),
+        trimLevel: buffer.readUInt8(152),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(162)),
+      },
+      {
+        faderLevel: buffer.readUInt8(175),
+        trimLevel: buffer.readUInt8(176),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(186)),
+      },
+      {
+        faderLevel: buffer.readUInt8(199),
+        trimLevel: buffer.readUInt8(200),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(210)),
+      },
+      {
+        faderLevel: buffer.readUInt8(223),
+        trimLevel: buffer.readUInt8(224),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(234)),
+      },
+      {
+        faderLevel: buffer.readUInt8(247),
+        trimLevel: buffer.readUInt8(248),
+        crossfaderAssign: getTcNetMixerCrossfaderAssign(buffer.readUInt8(258)),
+      },
+    ],
   };
 };
 

--- a/packages/tcnet/src/protocol.ts
+++ b/packages/tcnet/src/protocol.ts
@@ -549,10 +549,6 @@ export type TCNetMetadataDataPacket = TCNetDataPacket<'METADATA'> & {
   trackArtist: string;
   trackTitle: string;
   trackKey: number;
-  /**
-   * @deprecated Note that ShowKontrol seems to not consistently send the correct
-   * trackID here, and you need to rely on the trackID from the status packet instead.
-   */
   trackId: number;
 };
 


### PR DESCRIPTION
Addressing some of the lower-hanging fruit from ShowKontrol v26.5.12, the remainder of the new functionality has been ticketed in #141