### PR TITLE
Enable blockExoticSubdeps again

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,6 @@ publicHoistPattern:
   - 'electron*'
 minimumReleaseAge: 10080 # 7 days
 minimumReleaseAgeStrict: true
-blockExoticSubdeps: false # TODO: https://github.com/ArcaneWizards/open-source/issues/73
 minimumReleaseAgeExclude:
   - '@arcanejs/diff@0.6.0'
   - '@arcanejs/protocol@0.9.0'


### PR DESCRIPTION
fixes #73

Given that we have to pin `@electron/rebuild` for the build to work in recent windows GitHub Actions runners, we are no longer facing this issue and so can enable this security feature again.