### PR TITLE
Introduce ShowFileConfig and other related changes

### DIFF
--- a/.changeset/big-ghosts-trade.md
+++ b/.changeset/big-ghosts-trade.md
@@ -1,0 +1,11 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Expand user-actions module with more utilities
+
+- `ActionResponse` type, designed to allow for more rich error messages from
+  e.g. server actions
+- `mapUserActionState` (basic functional map function over `UserActionState`)
+- `useUserAction` - a react hook for managing state relating to user actions
+  and promise-based calls

--- a/.changeset/early-bees-take.md
+++ b/.changeset/early-bees-take.md
@@ -1,0 +1,5 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Add sigil-grid tailwind utility classes

--- a/.changeset/every-pans-cry.md
+++ b/.changeset/every-pans-cry.md
@@ -1,0 +1,5 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Add vAligh attribute to ControlLabel

--- a/.changeset/fine-roses-show.md
+++ b/.changeset/fine-roses-show.md
@@ -1,0 +1,10 @@
+---
+'@arcanewizards/sigil': minor
+---
+
+Introduce a new `ShowFileConfig` component
+
+Introduce a new component for the UI / frontend for consistently managing show
+files across sigil-based apps. The first usage of this component will be in
+Arcane Desktop, but additional usages (e.g. timecode-toolbox) are expected
+later on.

--- a/.changeset/silent-bags-make.md
+++ b/.changeset/silent-bags-make.md
@@ -1,0 +1,8 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Introduce ControlFileButton component
+
+This is a special-case of a ControlButton,
+designed to load files from the users' system.

--- a/packages/sigil/package.json
+++ b/packages/sigil/package.json
@@ -65,6 +65,12 @@
       "import": "./dist/frontend/preferences.js",
       "require": "./dist/frontend/preferences.cjs"
     },
+    "./frontend/showfiles": {
+      "@arcanewizards/source": "./src/frontend/showfiles.tsx",
+      "types": "./dist/frontend/showfiles.d.ts",
+      "import": "./dist/frontend/showfiles.js",
+      "require": "./dist/frontend/showfiles.cjs"
+    },
     "./frontend/spinner": {
       "@arcanewizards/source": "./src/frontend/spinner.tsx",
       "types": "./dist/frontend/spinner.d.ts",

--- a/packages/sigil/src/frontend/controls/buttons.tsx
+++ b/packages/sigil/src/frontend/controls/buttons.tsx
@@ -2,6 +2,8 @@ import {
   ComponentPropsWithoutRef,
   CSSProperties,
   forwardRef,
+  useCallback,
+  useRef,
   type ReactNode,
 } from 'react';
 import { cn } from '@arcanejs/toolkit-frontend/util';
@@ -216,6 +218,56 @@ export const CheckboxControlButton = forwardRef<
 ));
 
 CheckboxControlButton.displayName = 'CheckboxControlButton';
+
+export type ControlFileButtonProps = Omit<ControlButtonProps, 'onClick'> &
+  Pick<ComponentPropsWithoutRef<'input'>, 'accept' | 'multiple'> & {
+    onFilesSelected: (files: FileList) => Promise<void>;
+  };
+
+export const ControlFileButton = forwardRef<
+  HTMLButtonElement,
+  ControlFileButtonProps
+>(({ onFilesSelected, accept, multiple, children, ...props }, ref) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files) {
+        onFilesSelected(event.target.files).finally(() => {
+          // Reset the input value to allow re-selecting the same file
+          // But only after promise has resolded, and so files have been read
+          event.target.value = '';
+        });
+      }
+    },
+    [onFilesSelected],
+  );
+
+  return (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        style={{ display: 'none' }}
+        onChange={handleChange}
+      />
+      <ControlButton
+        title="Import spell"
+        onClick={handleClick}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </ControlButton>
+    </>
+  );
+});
 
 export type LongPressableControlButtonProps = Omit<
   ControlButtonFrameProps,

--- a/packages/sigil/src/frontend/controls/content.tsx
+++ b/packages/sigil/src/frontend/controls/content.tsx
@@ -58,11 +58,20 @@ export type ControlLabelProps = ComponentPropsWithoutRef<'label'> & {
   position?: ControlPosition;
   disabled?: boolean;
   nonMicro?: boolean;
+  vAlign?: 'start' | 'center' | 'end';
 };
 
 export const ControlLabel = forwardRef<HTMLLabelElement, ControlLabelProps>(
   (
-    { className, disabled, nonMicro, position = 'label', subgrid, ...props },
+    {
+      className,
+      disabled,
+      nonMicro,
+      position = 'label',
+      subgrid,
+      vAlign = 'center',
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -70,7 +79,10 @@ export const ControlLabel = forwardRef<HTMLLabelElement, ControlLabelProps>(
         {...props}
         ref={ref}
         className={cn(
-          'flex items-center justify-end gap-0.6 p-0.6',
+          'flex justify-end gap-0.6 p-0.6',
+          cnd(vAlign === 'start', 'items-start'),
+          cnd(vAlign === 'center', 'items-center'),
+          cnd(vAlign === 'end', 'items-end'),
           clsControlPosition(position),
           cnd(nonMicro, 'max-[550px]:hidden'),
           cnd(disabled, 'opacity-50'),
@@ -95,7 +107,7 @@ export const ControlDetails = forwardRef<HTMLDivElement, ControlDetailsProps>(
       {...props}
       ref={ref}
       className={cn(
-        'flex items-center px-0.3 text-sigil-foreground-muted',
+        'flex items-center px-0.3 py-0.6 text-sigil-foreground-muted',
         clsControlPosition(position),
         cnd(align === 'start', 'justify-start'),
         cnd(align === 'center', 'justify-center'),

--- a/packages/sigil/src/frontend/showfiles.tsx
+++ b/packages/sigil/src/frontend/showfiles.tsx
@@ -1,0 +1,606 @@
+import { cn } from '@arcanejs/toolkit-frontend/util';
+import { ComponentProps, FC, useCallback, useState } from 'react';
+import {
+  clsControlPosition,
+  ControlButton,
+  ControlButtonGroup,
+  ControlDialog,
+  ControlDialogButtons,
+  ControlFileButton,
+  ControlInput,
+  ControlLabel,
+  ControlParagraph,
+  ControlPosition,
+} from './controls';
+import { cnd } from './styling';
+import { TooltipBoundary, TooltipWrapper } from './tooltip';
+import {
+  ActionResponse,
+  LoadingWrapper,
+  success,
+  useUserAction,
+} from './user-actions';
+
+const ShowFileUuidBrand = Symbol('ShowFileUuid');
+
+export type ShowFileUuidBrand = typeof ShowFileUuidBrand;
+
+export type ShowFileUuid = string & {
+  _brand: ShowFileUuidBrand;
+};
+
+export const asShowFileUuid = (uuid: string): ShowFileUuid => {
+  return uuid as ShowFileUuid;
+};
+
+export type ShowFileConfigData = {
+  status:
+    | {
+        type: 'no-show-file';
+      }
+    | {
+        type: 'show-file-loaded';
+        hasChanges: boolean;
+        uuid: ShowFileUuid;
+      };
+  /**
+   * Map from showfile names to their filename UUIDs
+   */
+  showfiles: Record<string, ShowFileUuid>;
+  /**
+   * An error message to display if present
+   */
+  error?: string;
+};
+
+export type ShowFileConfigStrings = {
+  unsavedChanges: string;
+  changesSaved: string;
+  save: string;
+  saveAs: string;
+  load: string;
+  delete: string;
+  rename: string;
+  import: string;
+  export: string;
+  searchPlaceholder: string;
+  noShowFiles: string;
+  inUse: string;
+  dialogs: {
+    cancel: string;
+    nameLabel: string;
+    namePlaceholder: string;
+    emptyNameError: string;
+    saveAs: {
+      description: string;
+      save: string;
+    };
+    saveAsOverwriteConfirmation: {
+      title: string;
+      description: string;
+      overwrite: string;
+    };
+    loadUnsavedChangesConfirmation: {
+      title: string;
+      description: string;
+      load: string;
+    };
+    deleteConfirmation: {
+      title: string;
+      description: string;
+      delete: string;
+    };
+    rename: {
+      title: string;
+      description: string;
+    };
+  };
+};
+
+export type ShowFileConfigProps = {
+  mimeType: {
+    extension: string;
+    mimeType: string;
+  };
+  data: ShowFileConfigData;
+  description?: string;
+  strings: ShowFileConfigStrings;
+  position?: ControlPosition;
+  onSave: () => ActionResponse<string | null>;
+  onSaveAs: (name: string) => ActionResponse<string | null>;
+  onLoad: (uuid: ShowFileUuid) => ActionResponse<string | null>;
+  /**
+   * Return the file content that should be exported for the given showfile.
+   */
+  onExport: (uuid: ShowFileUuid) => Promise<Blob>;
+  onDelete: (uuid: ShowFileUuid) => ActionResponse<string | null>;
+  onRename: (
+    uuid: ShowFileUuid,
+    newName: string,
+  ) => ActionResponse<string | null>;
+  onImport: (file: FileList) => ActionResponse<string | null>;
+};
+
+const Scroll: FC<ComponentProps<typeof TooltipBoundary>> = ({
+  className,
+  ...props
+}) => (
+  <TooltipBoundary
+    {...props}
+    className={cn('flex flex-col overflow-y-auto scrollbar-sigil', className)}
+  />
+);
+
+type DialogMode =
+  | {
+      mode: 'save-as';
+      name: string;
+      error?: string;
+    }
+  | {
+      mode: 'save-as-overwrite-confirmation';
+      name: string;
+    }
+  | {
+      mode: 'load-unsaved-changes-confirmation';
+      uuid: ShowFileUuid;
+    }
+  | {
+      mode: 'delete-confirmation';
+      uuid: ShowFileUuid;
+    }
+  | {
+      mode: 'rename';
+      uuid: ShowFileUuid;
+      name: string;
+      error?: string;
+    }
+  | null;
+
+const getDialogTitle = (
+  mode: DialogMode,
+  strings: ShowFileConfigStrings,
+): string => {
+  switch (mode?.mode) {
+    case 'save-as':
+      return strings.saveAs;
+    case 'save-as-overwrite-confirmation':
+      return strings.dialogs.saveAsOverwriteConfirmation.title;
+    case 'load-unsaved-changes-confirmation':
+      return strings.dialogs.loadUnsavedChangesConfirmation.title;
+    case 'delete-confirmation':
+      return strings.dialogs.deleteConfirmation.title;
+    case 'rename':
+      return strings.dialogs.rename.title;
+    default:
+      return '';
+  }
+};
+
+export const ShowFileConfig: FC<ShowFileConfigProps> = ({
+  mimeType,
+  data,
+  description,
+  strings,
+  position,
+  onSave,
+  onSaveAs,
+  onExport,
+  onImport,
+  onLoad,
+  onDelete,
+  onRename,
+}) => {
+  const unsavedChanges =
+    data.status.type === 'no-show-file' || data.status.hasChanges;
+  const canSaveCurrentFile =
+    data.status.type === 'show-file-loaded' && data.status.hasChanges;
+
+  /** When set, it will be a success message to display to the user */
+  const [userAction, performAction] = useUserAction<string | null>();
+
+  const [dialogMode, setDialogMode] = useState<DialogMode>(null);
+
+  const onSaveButtonClicked = useCallback(() => {
+    performAction(() => onSave());
+  }, [onSave, performAction]);
+
+  const onSaveAsButtonClicked = useCallback(() => {
+    setDialogMode({ mode: 'save-as', name: '' });
+  }, []);
+
+  const onExportButtonClicked = useCallback(
+    (name: string, uuid: ShowFileUuid) => {
+      performAction(() =>
+        onExport(uuid).then((blob) => {
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `${name}.${mimeType.extension}`;
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+          URL.revokeObjectURL(url);
+          return success(null);
+        }),
+      );
+    },
+    [performAction, onExport, mimeType.extension],
+  );
+
+  const dialogClosed = useCallback(() => {
+    setDialogMode(null);
+  }, []);
+
+  const onSaveAsName = useCallback(
+    (name: string) => {
+      if (name.trim() === '') {
+        setDialogMode({
+          mode: 'save-as',
+          name: '',
+          error: strings.dialogs.emptyNameError,
+        });
+        return;
+      }
+      const existingName = Object.keys(data.showfiles).includes(name);
+      if (existingName) {
+        setDialogMode({ mode: 'save-as-overwrite-confirmation', name });
+      } else {
+        performAction(() => onSaveAs(name));
+        setDialogMode(null);
+      }
+    },
+    [data.showfiles, onSaveAs, performAction, strings],
+  );
+
+  const onSaveAsSubmit = useCallback(() => {
+    if (dialogMode?.mode !== 'save-as') return;
+    onSaveAsName(dialogMode.name);
+  }, [dialogMode, onSaveAsName]);
+
+  const onSaveAsInputChanged = useCallback(
+    (name: string, enterPressed: boolean) => {
+      setDialogMode((current) => {
+        if (!current || current.mode !== 'save-as') return current;
+        return { ...current, name };
+      });
+      if (enterPressed) {
+        onSaveAsName(name);
+      }
+    },
+    [onSaveAsName],
+  );
+
+  const onRenameWithName = useCallback(
+    (uuid: ShowFileUuid, name: string) => {
+      if (name.trim() === '') {
+        setDialogMode({
+          mode: 'rename',
+          uuid,
+          name: '',
+          error: strings.dialogs.emptyNameError,
+        });
+        return;
+      }
+      performAction(() => onRename(uuid, name));
+      setDialogMode(null);
+    },
+    [onRename, performAction, strings],
+  );
+
+  const onRenameSubmit = useCallback(() => {
+    if (dialogMode?.mode !== 'rename') return;
+    onRenameWithName(dialogMode.uuid, dialogMode.name);
+  }, [dialogMode, onRenameWithName]);
+
+  const onRenameInputChanged = useCallback(
+    (name: string, enterPressed: boolean) => {
+      setDialogMode((current) => {
+        if (!current || current.mode !== 'rename') return current;
+        return { ...current, name };
+      });
+      if (enterPressed && dialogMode?.mode === 'rename') {
+        onRenameWithName(dialogMode.uuid, name);
+      }
+    },
+    [dialogMode, onRenameWithName],
+  );
+
+  const onImportFilesSelected = useCallback(
+    (files: FileList) =>
+      performAction(() => onImport(files).then(() => success(null))),
+    [onImport, performAction],
+  );
+
+  const onLoadButtonClicked = useCallback(
+    (uuid: ShowFileUuid) => {
+      if (unsavedChanges) {
+        setDialogMode({ mode: 'load-unsaved-changes-confirmation', uuid });
+      } else {
+        performAction(() => onLoad(uuid));
+      }
+    },
+    [unsavedChanges, onLoad, performAction],
+  );
+
+  return (
+    <LoadingWrapper
+      action={userAction}
+      className={cn('flex flex-col gap-0.5', clsControlPosition(position))}
+    >
+      {dialogMode && (
+        <ControlDialog
+          dialogClosed={dialogClosed}
+          title={getDialogTitle(dialogMode, strings)}
+        >
+          <>
+            {dialogMode.mode === 'save-as' && (
+              <>
+                <ControlParagraph position="row">
+                  {strings.dialogs.saveAs.description}
+                </ControlParagraph>
+                <ControlLabel>{strings.dialogs.nameLabel}</ControlLabel>
+                <ControlInput
+                  value={dialogMode.name}
+                  onChange={onSaveAsInputChanged}
+                  placeholder={strings.dialogs.namePlaceholder}
+                  position="all"
+                />
+                {dialogMode.error && (
+                  <ControlParagraph position="row" mode="warning">
+                    {dialogMode.error}
+                  </ControlParagraph>
+                )}
+                <ControlDialogButtons>
+                  <ControlButton onClick={dialogClosed} variant="large">
+                    {strings.dialogs.cancel}
+                  </ControlButton>
+                  <ControlButton onClick={onSaveAsSubmit} variant="large">
+                    {strings.dialogs.saveAs.save}
+                  </ControlButton>
+                </ControlDialogButtons>
+              </>
+            )}
+            {dialogMode.mode === 'save-as-overwrite-confirmation' && (
+              <>
+                <ControlParagraph position="row">
+                  {strings.dialogs.saveAsOverwriteConfirmation.description}
+                </ControlParagraph>
+                <ControlDialogButtons>
+                  <ControlButton onClick={dialogClosed} variant="large">
+                    {strings.dialogs.cancel}
+                  </ControlButton>
+                  <ControlButton
+                    onClick={() => {
+                      performAction(() => onSaveAs(dialogMode.name));
+                      setDialogMode(null);
+                    }}
+                    variant="large"
+                    destructive
+                  >
+                    {strings.dialogs.saveAsOverwriteConfirmation.overwrite}
+                  </ControlButton>
+                </ControlDialogButtons>
+              </>
+            )}
+            {dialogMode.mode === 'load-unsaved-changes-confirmation' && (
+              <>
+                <ControlParagraph position="row">
+                  {strings.dialogs.loadUnsavedChangesConfirmation.description}
+                </ControlParagraph>
+                <ControlDialogButtons>
+                  <ControlButton onClick={dialogClosed} variant="large">
+                    {strings.dialogs.cancel}
+                  </ControlButton>
+                  <ControlButton
+                    onClick={() => {
+                      performAction(() => onLoad(dialogMode.uuid));
+                      setDialogMode(null);
+                    }}
+                    variant="large"
+                  >
+                    {strings.dialogs.loadUnsavedChangesConfirmation.load}
+                  </ControlButton>
+                </ControlDialogButtons>
+              </>
+            )}
+            {dialogMode.mode === 'delete-confirmation' && (
+              <>
+                <ControlParagraph position="row">
+                  {strings.dialogs.deleteConfirmation.description}
+                </ControlParagraph>
+                <ControlDialogButtons>
+                  <ControlButton onClick={dialogClosed} variant="large">
+                    {strings.dialogs.cancel}
+                  </ControlButton>
+                  <ControlButton
+                    onClick={() => {
+                      performAction(() => onDelete(dialogMode.uuid));
+                      setDialogMode(null);
+                    }}
+                    variant="large"
+                    destructive
+                  >
+                    {strings.dialogs.deleteConfirmation.delete}
+                  </ControlButton>
+                </ControlDialogButtons>
+              </>
+            )}
+            {dialogMode.mode === 'rename' && (
+              <>
+                <ControlParagraph position="row">
+                  {strings.dialogs.rename.description}
+                </ControlParagraph>
+                <ControlLabel>{strings.dialogs.nameLabel}</ControlLabel>
+                <ControlInput
+                  value={dialogMode.name}
+                  onChange={onRenameInputChanged}
+                  placeholder={strings.dialogs.namePlaceholder}
+                  position="all"
+                />
+                {dialogMode.error && (
+                  <ControlParagraph position="row" mode="warning">
+                    {dialogMode.error}
+                  </ControlParagraph>
+                )}
+                <ControlDialogButtons>
+                  <ControlButton onClick={dialogClosed} variant="large">
+                    {strings.dialogs.cancel}
+                  </ControlButton>
+                  <ControlButton onClick={onRenameSubmit} variant="large">
+                    {strings.rename}
+                  </ControlButton>
+                </ControlDialogButtons>
+              </>
+            )}
+          </>
+        </ControlDialog>
+      )}
+      {description && (
+        <div className="px-0.3 py-0.6 text-sigil-foreground-muted">
+          {description}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-sigil-control-gap">
+        <ControlButton
+          onClick={onSaveAsButtonClicked}
+          variant="large"
+          icon="save_as"
+        >
+          {strings.saveAs}
+        </ControlButton>
+        <ControlButton
+          onClick={onSaveButtonClicked}
+          variant="large"
+          icon="save"
+          disabled={!canSaveCurrentFile}
+        >
+          {strings.save}
+        </ControlButton>
+        <span
+          className={cn(
+            'px-0.3',
+            cnd(
+              unsavedChanges,
+              `text-sigil-warning-foreground`,
+              `text-sigil-success-foreground`,
+            ),
+          )}
+        >
+          {unsavedChanges ? strings.unsavedChanges : strings.changesSaved}
+        </span>
+        <div className="grow" />
+        <ControlFileButton
+          variant="large"
+          icon="file_open"
+          accept={`.${mimeType.extension}, ${mimeType.mimeType}`}
+          multiple
+          onFilesSelected={onImportFilesSelected}
+        >
+          {strings.import}
+        </ControlFileButton>
+      </div>
+      {/* eslint-disable-next-line better-tailwindcss/enforce-consistent-line-wrapping */}
+      <Scroll className="max-h-[200px] border border-sigil-border bg-sigil-border">
+        {Object.keys(data.showfiles).length === 0 && (
+          <div
+            className="
+              w-full bg-sigil-bg-dark p-1 text-center
+              text-sigil-foreground-muted italic
+            "
+          >
+            {strings.noShowFiles}
+          </div>
+        )}
+        <div className="sigil-grid-table-basic w-full">
+          {Object.entries(data.showfiles)
+            .sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
+            .map(([name, uuid]) => (
+              <div key={name} className="group sigil-grid-table-basic-subgrid">
+                <TooltipWrapper tooltip={strings.load}>
+                  <button
+                    onClick={() => onLoadButtonClicked(uuid)}
+                    className={cn(
+                      `
+                        sigil-grid-pos-name flex cursor-pointer items-center
+                        gap-1 border-none bg-sigil-bg-dark p-1 text-[0.7rem]
+                        text-sigil-foreground
+                        group-hover:bg-sigil-bg-light
+                        hover:bg-sigil-control-button-bg-hover
+                        hover:text-sigil-control-button-fg-hover
+                      `,
+                      cnd(
+                        data.status.type === 'show-file-loaded' &&
+                          data.status.uuid === uuid,
+                        `
+                          text-sigil-usage-hint-foreground
+                          hover:text-sigil-usage-hint-foreground
+                        `,
+                      ),
+                    )}
+                  >
+                    <span>{name}</span>
+                    <span className="grow" />
+                    {data.status.type === 'show-file-loaded' &&
+                      data.status.uuid === uuid && (
+                        <span
+                          className={cn(`
+                            rounded-arcane-btn border
+                            border-sigil-usage-hint-border
+                            bg-sigil-usage-hint-background px-0.3 py-0.5
+                            text-[0.7rem] text-sigil-usage-hint-text
+                          `)}
+                        >
+                          {strings.inUse}
+                        </span>
+                      )}
+                  </button>
+                </TooltipWrapper>
+                <ControlButtonGroup
+                  className="
+                    sigil-grid-pos-controls bg-sigil-bg-dark
+                    group-hover:bg-sigil-bg-light
+                  "
+                >
+                  <ControlButton
+                    onClick={() =>
+                      setDialogMode({ mode: 'delete-confirmation', uuid })
+                    }
+                    variant="large"
+                    icon="delete"
+                    title={strings.delete}
+                  />
+                  <ControlButton
+                    onClick={() =>
+                      setDialogMode({ mode: 'rename', uuid, name })
+                    }
+                    variant="large"
+                    icon="edit"
+                    title={strings.rename}
+                  />
+                  <ControlButton
+                    onClick={() => onExportButtonClicked(name, uuid)}
+                    variant="table-row"
+                    icon="publish"
+                    title={strings.export}
+                  />
+                </ControlButtonGroup>
+              </div>
+            ))}
+        </div>
+      </Scroll>
+      {data.error && (
+        <div className="px-0.3 py-0.6 text-sigil-error-foreground">
+          {data.error}
+        </div>
+      )}
+      {userAction.success && userAction.data && (
+        <div className="px-0.3 py-0.6 text-sigil-success-foreground">
+          {userAction.data}
+        </div>
+      )}
+    </LoadingWrapper>
+  );
+};
+
+ShowFileConfig.displayName = 'ShowFileConfig';

--- a/packages/sigil/src/frontend/styles/sigil.css
+++ b/packages/sigil/src/frontend/styles/sigil.css
@@ -191,6 +191,29 @@
   }
 }
 
+@utility sigil-grid-table-basic {
+  display: grid;
+  grid-template-columns: [name-start] 1fr [name-end controls-start] max-content [controls-end];
+  grid-gap: var(--sigil-control-gap);
+  font-size: 0.7rem;
+}
+
+@utility sigil-grid-table-basic-subgrid {
+  display: grid;
+  grid-area: auto / name-start / span 1 / controls-end;
+  grid-template-columns: subgrid;
+}
+
+@utility sigil-grid-pos-name {
+  grid-column: name-start / name-end;
+  grid-row: auto / span 1;
+}
+
+@utility sigil-grid-pos-controls {
+  grid-column: controls-start / controls-end;
+  grid-row: auto / span 1;
+}
+
 .arcane-theme-root {
   /*
    * Any component-specific styling variables

--- a/packages/sigil/src/frontend/user-actions.tsx
+++ b/packages/sigil/src/frontend/user-actions.tsx
@@ -1,9 +1,25 @@
-import { FC } from 'react';
+import { FC, useCallback, useMemo, useState, useTransition } from 'react';
 import { cn } from '@arcanejs/toolkit-frontend/util';
 import { Spinner } from './spinner';
 import { Alert, AlertDescription, AlertTitle } from './alert';
 import { Icon } from '@arcanejs/toolkit-frontend/components/core';
 import { cnd } from './styling';
+
+export type ActionResponse<T> = Promise<
+  | {
+      success: true;
+      data: T;
+    }
+  | {
+      success: false;
+      title: string;
+      details?: string;
+    }
+>;
+
+export const success = <T,>(data: T): Awaited<ActionResponse<T>> => {
+  return { success: true, data };
+};
 
 export type InternalUserActionState<T> =
   | {
@@ -80,6 +96,66 @@ export const prepareUserActionsState = <T,>(
         details: state.details,
       };
   }
+};
+
+export const mapUserActionState = <T, U>(
+  state: UserActionState<T>,
+  transform: (data: T) => U,
+): UserActionState<U> => {
+  if (state.success) {
+    return {
+      idle: false,
+      success: true,
+      data: transform(state.data),
+      loading: false,
+      error: false,
+    };
+  }
+  return state as UserActionState<U>;
+};
+
+export const useUserAction = <T,>(initial?: T) => {
+  const [state, setState] = useState<InternalUserActionState<T>>(
+    initial ? { type: 'success', data: initial } : { type: 'idle' },
+  );
+
+  const [isPending, startTransition] = useTransition();
+
+  const performAction = useCallback(
+    async (action: () => ActionResponse<T>) =>
+      startTransition(async () => {
+        try {
+          const result = await action();
+          if (!result.success) {
+            setState({
+              type: 'error',
+              title: result.title,
+              details: result.details,
+            });
+            return;
+          }
+          setState({ type: 'success', data: result.data });
+        } catch (error) {
+          setState({
+            type: 'error',
+            title: 'An unexpected error ocurred',
+            details: `${error}`,
+          });
+        }
+      }),
+    [],
+  );
+
+  const reset = useCallback(() => {
+    setState({ type: 'idle' });
+  }, []);
+
+  const returnState = useMemo(
+    () => prepareUserActionsState(state, isPending),
+    [state, isPending],
+  );
+
+  return [returnState, performAction, reset] as const;
 };
 
 type UserActionAlertProps = {

--- a/packages/sigil/tsup.config.ts
+++ b/packages/sigil/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'src/frontend/dialogs.tsx',
     'src/frontend/input.ts',
     'src/frontend/preferences.ts',
+    'src/frontend/showfiles.tsx',
     'src/frontend/spinner.tsx',
     'src/frontend/styling.ts',
     'src/frontend/styling.hooks.ts',


### PR DESCRIPTION
Introduce a new component for the UI / frontend for consistently managing show files across sigil-based apps. The first usage of this component will be in Arcane Desktop, but additional usages (e.g. timecode-toolbox) are expected later on.

This commit / PR also creates a bunch of other non-breaking changes that this new component depends on.