### PR TITLE
Avoid calling setPositionState with bad position

### DIFF
--- a/.changeset/wild-balloons-hang.md
+++ b/.changeset/wild-balloons-hang.md
@@ -1,0 +1,8 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Avoid calling setPositionState with bad position
+
+Avoid calling `setPositionState` in browser media session with a position that
+is less than 0 or greater than the duration of the loaded media.

--- a/packages/sigil/src/frontend/media-session.ts
+++ b/packages/sigil/src/frontend/media-session.ts
@@ -45,8 +45,13 @@ export const createBrowserMediaSession = (): MediaSessionControl => {
       navigator.mediaSession.setPositionState({
         duration: durationMillis / 1000,
         position:
-          Math.max(0, (Date.now() - state.effectiveStartTime) * state.speed) /
-          1000,
+          Math.max(
+            0,
+            Math.min(
+              (Date.now() - state.effectiveStartTime) * state.speed,
+              durationMillis,
+            ),
+          ) / 1000,
         playbackRate: state.speed,
       });
       return;
@@ -55,7 +60,8 @@ export const createBrowserMediaSession = (): MediaSessionControl => {
     navigator.mediaSession.playbackState = 'paused';
     navigator.mediaSession.setPositionState({
       duration: durationMillis / 1000,
-      position: state.currentTimeMillis / 1000,
+      position:
+        Math.max(0, Math.min(state.currentTimeMillis, durationMillis)) / 1000,
     });
   };
 


### PR DESCRIPTION
Avoid calling setPositionState with a position that is less than 0 or greater than the duration of the loaded media.