### PR TITLE
Add optional extra system information

### DIFF
--- a/.changeset/empty-olives-read.md
+++ b/.changeset/empty-olives-read.md
@@ -1,0 +1,8 @@
+---
+'@arcanewizards/sigil': patch
+---
+
+Add optional extra system information
+
+Allow a sigil app to include additional system information to display in
+the Debugger component, such as additional paths.

--- a/packages/sigil/src/app-shell.tsx
+++ b/packages/sigil/src/app-shell.tsx
@@ -19,6 +19,7 @@ export type AppShellProps = {
   logEventEmitter: SigilLogEventEmitter;
   shutdownContext: ShutdownContextData;
   children: ReactNode;
+  extraSystemInformation?: Record<string, string>;
 };
 
 export const AppShell = ({
@@ -29,6 +30,7 @@ export const AppShell = ({
   logEventEmitter,
   shutdownContext,
   children,
+  extraSystemInformation,
 }: AppShellProps): JSX.Element => {
   const [logs, setLogs] = useState<AppRootLogEntry[]>([]);
 
@@ -44,8 +46,13 @@ export const AppShell = ({
   }, [logEventEmitter]);
 
   const system = useMemo(
-    () => createSystemInformation({ dataDirectory, version }),
-    [dataDirectory, version],
+    () =>
+      createSystemInformation({
+        dataDirectory,
+        version,
+        extra: extraSystemInformation,
+      }),
+    [dataDirectory, version, extraSystemInformation],
   );
 
   const appInformation: AppInformationContextData = useMemo(

--- a/packages/sigil/src/backend/app-root.ts
+++ b/packages/sigil/src/backend/app-root.ts
@@ -33,6 +33,7 @@ const DEFAULT_PROPS: AppRootProps = {
     cwd: 'unknown',
     os: 'unknown',
     dataDirectory: 'unknown',
+    extra: {},
   },
 };
 

--- a/packages/sigil/src/frontend/debugger.tsx
+++ b/packages/sigil/src/frontend/debugger.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useCallback, useEffect, useRef } from 'react';
+import { FC, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useBrowserContext } from './browser-context';
 import { useDebuggerContext, useSystemInformation } from './context';
 import { AppRootLogEntryStackFrame } from '../shared/types';
@@ -79,6 +79,22 @@ export const Debugger: FC<DebuggerProps> = ({ title, className }) => {
     scrollToBottomIfRequired();
   }, [scrollToBottomIfRequired]);
 
+  const systemInfo = useMemo(() => {
+    let info = '';
+
+    info += `OS: ${system.os}\n`;
+    info += `Version: ${system.version}\n`;
+    info += `App Path: ${system.appPath}\n`;
+    info += `CWD: ${system.cwd}\n`;
+    info += `Data Directory: ${system.dataDirectory}\n`;
+
+    for (const [key, value] of Object.entries(system.extra ?? {})) {
+      info += `${key}: ${value}\n`;
+    }
+
+    return info;
+  }, [system]);
+
   return (
     <div className={cn('flex flex-col', className)}>
       <ToolbarWrapper>
@@ -112,7 +128,7 @@ export const Debugger: FC<DebuggerProps> = ({ title, className }) => {
           select-text scrollbar-sigil
         "
       >
-        {`OS: ${system.os}\nVersion: ${system.version}\nApp Path: ${system.appPath}\nCWD: ${system.cwd}\nData Directory: ${system.dataDirectory}`}
+        {systemInfo}
       </pre>
       <div
         ref={scrollRef}

--- a/packages/sigil/src/runtime.tsx
+++ b/packages/sigil/src/runtime.tsx
@@ -90,9 +90,11 @@ const getStackFramesFromError = (error: unknown): AppRootLogEntryStackFrame => {
 export const createSystemInformation = ({
   dataDirectory,
   version,
+  extra,
 }: {
   dataDirectory: string;
   version: string;
+  extra?: SystemInformation['extra'];
 }): SystemInformation => {
   return {
     appPath: process.execPath,
@@ -100,6 +102,7 @@ export const createSystemInformation = ({
     os: process.platform,
     version,
     dataDirectory,
+    extra,
   };
 };
 

--- a/packages/sigil/src/shared/types.ts
+++ b/packages/sigil/src/shared/types.ts
@@ -20,4 +20,5 @@ export type SystemInformation = {
   appPath: string;
   cwd: string;
   dataDirectory: string;
+  extra?: Record<string, string>;
 };


### PR DESCRIPTION
Allow a sigil app to include additional system information to display in the Debugger component, such as additional paths.