### PR TITLE
Switch to native Bonjour API to request local network access on Mac

### DIFF
--- a/.changeset/cool-bushes-dress.md
+++ b/.changeset/cool-bushes-dress.md
@@ -1,0 +1,11 @@
+---
+'@arcanewizards/timecode-toolbox': patch
+---
+
+Use native MacOS API to request local network access
+
+On some macs, despite the 2 releases since 0.4.7,
+local network access was still blocked.
+
+We're now trying a different approach to request local network access when it's
+needed that should, hopefully, resolve the issue

--- a/.changeset/cuddly-donkeys-shake.md
+++ b/.changeset/cuddly-donkeys-shake.md
@@ -1,0 +1,26 @@
+---
+'@arcanewizards/net-utils-native': minor
+'@arcanewizards/net-utils': minor
+---
+
+Request macOS local network access via NWBrowser
+
+Since macOS 15, an app must be granted Local Network access before it can reach
+LAN hosts, and without it a UDP send fails with `EHOSTUNREACH`. The permission
+is only evaluated when the app uses one of Apple's own networking APIs.
+
+`ensureLocalNetworkAccess` previously used `bonjour-service`, a pure-JavaScript
+mDNS implementation sending multicast over `dgram`. That never calls an Apple
+API, so it did not trigger the permission, and it failed silently: the denied
+multicast was dropped, no error was surfaced, and the function resolved on a
+timer regardless — reporting success while access was still denied.
+
+It has now moved to the new `@arcanewizards/net-utils-native` package,
+which calls `NWBrowser` from Network.framework through a small N-API module.
+
+`ensureLocalNetworkAccess` is no longer exported from `@arcanewizards/net-utils`,
+which drops its `bonjour-service` dependency and stays free of any native build
+step. Import it from `@arcanewizards/net-utils-native` instead.
+
+This is considered a breaking change for `@arcanewizards/net-utils`,
+but given that it's still pre-v1, we're doing a minor version bump.

--- a/.changeset/orange-garlics-say.md
+++ b/.changeset/orange-garlics-say.md
@@ -1,9 +1,0 @@
----
-'@arcanewizards/timecode-toolbox': patch
----
-
-Update net-utils, and use ensureLocalNetworkAccess
-
-`ensureLocalNetworkAccess` and usage of bonjour has now been migrated into the
-`net-utils` NPM package. This will allow for usage in Arcane Desktop to fix the
-same issue there.

--- a/apps/timecode-toolbox-desktop/forge.config.js
+++ b/apps/timecode-toolbox-desktop/forge.config.js
@@ -3,6 +3,7 @@
 const PACKAGED_RUNTIME_DEPENDENCIES = [
   '@arcanewizards/electron-media-service',
   '@arcanewizards/midi',
+  '@arcanewizards/net-utils-native',
   'bindings',
   'file-uri-to-path',
   'material-symbols',
@@ -12,6 +13,11 @@ const PACKAGED_RUNTIME_DEPENDENCIES = [
 
 const STRICT_FILTERS = {
   '/node_modules/@arcanewizards/midi': ['dist', 'native', 'package.json'],
+  '/node_modules/@arcanewizards/net-utils-native': [
+    'dist',
+    'native',
+    'package.json',
+  ],
 };
 
 const PACKAGED_RUNTIME_DEPENDENCY_PATHS = PACKAGED_RUNTIME_DEPENDENCIES.map(
@@ -62,8 +68,8 @@ const shouldIgnorePackagedPath = (filePath) => {
         }
         return isIgnored;
       }
-      return false;
     }
+    return false;
   }
   return true;
 };
@@ -84,7 +90,16 @@ module.exports = {
       },
       NSLocalNetworkUsageDescription:
         'Required for TCNet, and ArtNet to other devices',
-      NSBonjourServices: ['_http._tcp'],
+      // Must stay in sync with DEFAULT_SERVICE_TYPES in
+      // @arcanewizards/net-utils-native, which are browsed to request and
+      // confirm local network access.
+      NSBonjourServices: [
+        '_airplay._tcp',
+        '_raop._tcp',
+        '_companion-link._tcp',
+        '_googlecast._tcp',
+        '_http._tcp',
+      ],
     },
     osxSign:
       process.env.FULL_BUILD == 'false'

--- a/apps/timecode-toolbox-desktop/package.json
+++ b/apps/timecode-toolbox-desktop/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist",
     "build": "pnpm check:types && pnpm clean && cp ../../LICENSE ./LICENSE &&pnpm build:main && pnpm build:preload && pnpm build:frontend",
     "build:workspace": "pnpm -r --filter @arcanewizards/timecode-toolbox-desktop... build",
-    "build:main": "esbuild src/main.ts --bundle --platform=node --format=cjs --target=node20 --external:electron --external:@arcanewizards/electron-media-service --external:@arcanewizards/midi --outfile=dist/main.js",
+    "build:main": "esbuild src/main.ts --bundle --platform=node --format=cjs --target=node20 --external:electron --external:@arcanewizards/electron-media-service --external:@arcanewizards/midi --external:@arcanewizards/net-utils-native --outfile=dist/main.js",
     "build:preload": "esbuild src/preload.ts --bundle --platform=node --format=cjs --target=node20 --external:electron --outfile=dist/preload.js",
     "build:frontend": "esbuild src/frontend.ts --bundle --platform=browser --format=iife --conditions=@arcanewizards/source --outfile=dist/frontend.js",
     "start": "pnpm build && electron-forge start",
@@ -29,6 +29,7 @@
   "dependencies": {
     "@arcanewizards/electron-media-service": "^0.3.2",
     "@arcanewizards/midi": "workspace:^",
+    "@arcanewizards/net-utils-native": "workspace:^",
     "bindings": "^1.5.0",
     "file-uri-to-path": "^1.0.0",
     "material-symbols": "^0.25.3",

--- a/apps/timecode-toolbox/package.json
+++ b/apps/timecode-toolbox/package.json
@@ -82,7 +82,7 @@
     "@arcanejs/react-toolkit": "^0.16.2",
     "@arcanejs/toolkit": "^9.0.2",
     "@arcanewizards/midi": "workspace:^",
-    "bonjour-service": "^1.4.4",
+    "@arcanewizards/net-utils-native": "workspace:^",
     "pino": "^9.14.0",
     "pino-pretty": "^11.3.0",
     "react": "^19.2.4"

--- a/apps/timecode-toolbox/src/inputs/tcnet.tsx
+++ b/apps/timecode-toolbox/src/inputs/tcnet.tsx
@@ -29,10 +29,8 @@ import {
   TCNetConnectedNodes,
   TCNetPortUsage,
 } from '@arcanewizards/tcnet/types';
-import {
-  ensureLocalNetworkAccess,
-  NetworkPortStatus,
-} from '@arcanewizards/net-utils';
+import { NetworkPortStatus } from '@arcanewizards/net-utils';
+import { ensureLocalNetworkAccess } from '@arcanewizards/net-utils-native';
 import { StateSensitiveComponentProps } from '../types';
 
 type TcnetInputConnectionProps = StateSensitiveComponentProps & {

--- a/packages/net-utils-native/README.md
+++ b/packages/net-utils-native/README.md
@@ -1,0 +1,64 @@
+# `@arcanewizards/net-utils-native`
+
+[![](https://img.shields.io/npm/v/@arcanewizards/net-utils-native)](https://www.npmjs.com/package/@arcanewizards/net-utils-native)
+
+Native networking utilities that need platform APIs, currently macOS local
+network access.
+
+## Installation
+
+```sh
+pnpm add @arcanewizards/net-utils-native
+```
+
+## Requirements
+
+- Node.js `>=22.12.0 || >=23.1.0`
+- On macOS, Xcode Command Line Tools (the native module is compiled on install)
+
+On every other platform there is nothing to build, and the API resolves without
+doing any work.
+
+## Why this exists
+
+Since macOS 15, an application must be granted Local Network access before it
+can reach hosts on the LAN. Without it, sending a UDP packet to a local address
+fails with `EHOSTUNREACH`, which is indistinguishable from a genuine routing
+failure.
+
+The permission is only evaluated, and the prompt only raised, when the
+application uses one of Apple's own networking APIs. A pure-JavaScript mDNS
+implementation sending multicast over `dgram` does not qualify: the traffic is
+simply dropped, no prompt appears, and the failure is silent.
+
+This package calls `NWBrowser` from Network.framework through a small N-API
+module, so the request is correctly attributed to the containing application
+bundle and the system's answer is actually observable.
+
+## Usage
+
+```ts
+import { ensureLocalNetworkAccess } from '@arcanewizards/net-utils-native';
+
+await ensureLocalNetworkAccess(logger);
+```
+
+Rejects with a `LocalNetworkDeniedError` when access was explicitly denied.
+Resolves when access was confirmed, and also when the probe was inconclusive —
+a network with nothing to discover should not stop a connection being attempted.
+
+For the raw observations, use `probeLocalNetworkAccess`:
+
+```ts
+import { probeLocalNetworkAccess } from '@arcanewizards/net-utils-native';
+
+const result = await probeLocalNetworkAccess();
+// result.access: 'granted' | 'denied' | 'unknown'
+// result.events: every state change and discovered service, in order
+```
+
+## Info.plist
+
+An application using this package should declare, in addition to
+`NSLocalNetworkUsageDescription`, every browsed service type under
+`NSBonjourServices`. The defaults are exported as `DEFAULT_SERVICE_TYPES`.

--- a/packages/net-utils-native/eslint.config.mjs
+++ b/packages/net-utils-native/eslint.config.mjs
@@ -1,0 +1,28 @@
+import { defineConfig } from 'eslint/config';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+import {
+  tsParser,
+  js,
+  FlatCompat,
+} from '@arcanewizards/eslint-config/dependencies.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
+});
+
+export default defineConfig([
+  {
+    extends: compat.extends('@arcanewizards/eslint-config/library.js'),
+
+    languageOptions: {
+      parser: tsParser,
+    },
+  },
+]);

--- a/packages/net-utils-native/native/local-network-macos.mm
+++ b/packages/net-utils-native/native/local-network-macos.mm
@@ -1,0 +1,394 @@
+#include <Network/Network.h>
+#include <dispatch/dispatch.h>
+#include <node_api.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+namespace {
+
+/**
+ * A single observation delivered from the browser's dispatch queue back to the
+ * JavaScript thread. The JS layer records every event it receives so that the
+ * granted/denied rule can be derived (and revised) without changing this file.
+ */
+struct BrowseEvent {
+  std::string type;
+  std::string state;
+  std::string change;
+  std::string name;
+  uint32_t total = 0;
+  bool hasError = false;
+  int32_t errorDomain = 0;
+  int32_t errorCode = 0;
+};
+
+std::string BrowserStateName(nw_browser_state_t state) {
+  switch (state) {
+  case nw_browser_state_ready:
+    return "ready";
+  case nw_browser_state_failed:
+    return "failed";
+  case nw_browser_state_cancelled:
+    return "cancelled";
+  case nw_browser_state_waiting:
+    return "waiting";
+  case nw_browser_state_invalid:
+  default:
+    return "invalid";
+  }
+}
+
+void Throw(napi_env env, const std::string &message) {
+  napi_throw_error(env, nullptr, message.c_str());
+}
+
+napi_value CreateUndefined(napi_env env) {
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+void SetString(napi_env env, napi_value object, const char *key,
+               const std::string &value) {
+  napi_value string;
+  napi_create_string_utf8(env, value.c_str(), NAPI_AUTO_LENGTH, &string);
+  napi_set_named_property(env, object, key, string);
+}
+
+/**
+ * Delivers one BrowseEvent to the JavaScript callback.
+ */
+void EmitEvent(napi_env env, napi_value jsCallback, void *, void *data) {
+  std::unique_ptr<BrowseEvent> event(static_cast<BrowseEvent *>(data));
+
+  if (env == nullptr || jsCallback == nullptr) {
+    return;
+  }
+
+  napi_value object;
+  napi_create_object(env, &object);
+
+  SetString(env, object, "type", event->type);
+
+  if (!event->state.empty()) {
+    SetString(env, object, "state", event->state);
+  }
+  if (!event->change.empty()) {
+    SetString(env, object, "change", event->change);
+  }
+  if (!event->name.empty()) {
+    SetString(env, object, "name", event->name);
+  }
+
+  if (event->type == "result") {
+    napi_value total;
+    napi_create_uint32(env, event->total, &total);
+    napi_set_named_property(env, object, "total", total);
+  }
+
+  if (event->hasError) {
+    napi_value errorDomain;
+    napi_value errorCode;
+    napi_create_int32(env, event->errorDomain, &errorDomain);
+    napi_create_int32(env, event->errorCode, &errorCode);
+    napi_set_named_property(env, object, "errorDomain", errorDomain);
+    napi_set_named_property(env, object, "errorCode", errorCode);
+  }
+
+  napi_value global;
+  napi_get_global(env, &global);
+  napi_call_function(env, global, jsCallback, 1, &object, nullptr);
+}
+
+/**
+ * Shared between the wrapped handle and the Network.framework handler blocks.
+ *
+ * The blocks are copied and retained by the browser, and may run after the
+ * handle has been finalized, so the state is held by shared_ptr and captured by
+ * value rather than capturing the handle itself.
+ */
+struct BrowserState {
+  std::mutex mutex;
+  napi_threadsafe_function callback = nullptr;
+  bool finished = false;
+  uint32_t total = 0;
+
+  void Emit(std::unique_ptr<BrowseEvent> event) {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (callback == nullptr || finished) {
+      return;
+    }
+
+    BrowseEvent *payload = event.release();
+    napi_status status =
+        napi_call_threadsafe_function(callback, payload, napi_tsfn_nonblocking);
+    if (status != napi_ok) {
+      delete payload;
+    }
+  }
+
+  /**
+   * Stops further delivery and hands back the callback so the caller can
+   * release it outside of the lock.
+   */
+  napi_threadsafe_function Finish() {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (finished) {
+      return nullptr;
+    }
+    finished = true;
+    napi_threadsafe_function released = callback;
+    callback = nullptr;
+    return released;
+  }
+};
+
+void FinishAndRelease(const std::shared_ptr<BrowserState> &state) {
+  napi_threadsafe_function callback = state->Finish();
+  if (callback != nullptr) {
+    // napi_tsfn_release rather than napi_tsfn_abort, so that the final
+    // state event is still delivered to JavaScript.
+    napi_release_threadsafe_function(callback, napi_tsfn_release);
+  }
+}
+
+class NativeBrowser {
+public:
+  NativeBrowser(nw_browser_t browserRef, dispatch_queue_t queueRef,
+                std::shared_ptr<BrowserState> sharedState)
+      : browser(browserRef), queue(queueRef), state(std::move(sharedState)) {}
+
+  ~NativeBrowser() { Cancel(); }
+
+  void Cancel() {
+    if (browser != nullptr) {
+      nw_browser_cancel(browser);
+      nw_release(browser);
+      browser = nullptr;
+    }
+    if (queue != nullptr) {
+      dispatch_release(queue);
+      queue = nullptr;
+    }
+    FinishAndRelease(state);
+  }
+
+private:
+  nw_browser_t browser = nullptr;
+  dispatch_queue_t queue = nullptr;
+  std::shared_ptr<BrowserState> state;
+};
+
+void BrowserFinalizer(napi_env, void *data, void *) {
+  delete static_cast<NativeBrowser *>(data);
+}
+
+napi_value BrowserCancel(napi_env env, napi_callback_info callbackInfo) {
+  napi_value self;
+  napi_get_cb_info(env, callbackInfo, nullptr, nullptr, &self, nullptr);
+
+  NativeBrowser *browser = nullptr;
+  if (napi_unwrap(env, self, reinterpret_cast<void **>(&browser)) != napi_ok ||
+      browser == nullptr) {
+    Throw(env, "Local network browser handle is invalid.");
+    return CreateUndefined(env);
+  }
+
+  browser->Cancel();
+  return CreateUndefined(env);
+}
+
+bool ReadStringArgument(napi_env env, napi_value value, std::string &out) {
+  size_t length = 0;
+  if (napi_get_value_string_utf8(env, value, nullptr, 0, &length) != napi_ok) {
+    return false;
+  }
+
+  out.resize(length);
+  return napi_get_value_string_utf8(env, value, out.data(), length + 1,
+                                    &length) == napi_ok;
+}
+
+/**
+ * startBrowse(serviceType, domain, callback) -> { cancel() }
+ *
+ * Starts an NWBrowser for the given Bonjour service type. Browsing is the
+ * operation macOS uses to evaluate local network access, so starting it both
+ * triggers the permission prompt and surfaces the system's answer through the
+ * state handler.
+ */
+napi_value StartBrowse(napi_env env, napi_callback_info callbackInfo) {
+  size_t argc = 3;
+  napi_value args[3];
+  napi_get_cb_info(env, callbackInfo, &argc, args, nullptr, nullptr);
+
+  if (argc < 3) {
+    Throw(env, "startBrowse requires a service type, domain and callback.");
+    return CreateUndefined(env);
+  }
+
+  std::string serviceType;
+  if (!ReadStringArgument(env, args[0], serviceType) || serviceType.empty()) {
+    Throw(env, "startBrowse requires a non-empty service type.");
+    return CreateUndefined(env);
+  }
+
+  napi_valuetype domainType;
+  if (napi_typeof(env, args[1], &domainType) != napi_ok) {
+    Throw(env, "Unable to inspect domain.");
+    return CreateUndefined(env);
+  }
+
+  std::string domain;
+  bool hasDomain = domainType != napi_undefined && domainType != napi_null;
+  if (hasDomain && !ReadStringArgument(env, args[1], domain)) {
+    Throw(env, "startBrowse requires the domain to be a string or null.");
+    return CreateUndefined(env);
+  }
+
+  napi_valuetype callbackType;
+  if (napi_typeof(env, args[2], &callbackType) != napi_ok ||
+      callbackType != napi_function) {
+    Throw(env, "startBrowse requires the callback to be a function.");
+    return CreateUndefined(env);
+  }
+
+  nw_browse_descriptor_t descriptor =
+      nw_browse_descriptor_create_bonjour_service(
+          serviceType.c_str(), hasDomain ? domain.c_str() : nullptr);
+  if (descriptor == nullptr) {
+    Throw(env, "Unable to create a Bonjour browse descriptor.");
+    return CreateUndefined(env);
+  }
+
+  nw_parameters_t parameters = nw_parameters_create();
+  nw_browser_t browser = nw_browser_create(descriptor, parameters);
+  nw_release(descriptor);
+  if (parameters != nullptr) {
+    nw_release(parameters);
+  }
+
+  if (browser == nullptr) {
+    Throw(env, "Unable to create a local network browser.");
+    return CreateUndefined(env);
+  }
+
+  napi_value resourceName;
+  napi_create_string_utf8(env, "Local network browse callback",
+                          NAPI_AUTO_LENGTH, &resourceName);
+
+  napi_threadsafe_function callback = nullptr;
+  napi_status status = napi_create_threadsafe_function(
+      env, args[2], nullptr, resourceName, 0, 1, nullptr, nullptr, nullptr,
+      EmitEvent, &callback);
+  if (status != napi_ok) {
+    nw_release(browser);
+    Throw(env, "Unable to create the local network browse callback.");
+    return CreateUndefined(env);
+  }
+
+  // The JS layer keeps the event loop alive with its own timeout, so the
+  // callback should not hold the process open on its own.
+  napi_unref_threadsafe_function(env, callback);
+
+  auto state = std::make_shared<BrowserState>();
+  state->callback = callback;
+
+  dispatch_queue_t queue = dispatch_queue_create(
+      "com.arcanewizards.net-utils-native.browser", DISPATCH_QUEUE_SERIAL);
+  nw_browser_set_queue(browser, queue);
+
+  nw_browser_set_state_changed_handler(
+      browser, ^(nw_browser_state_t browserState, nw_error_t error) {
+        auto event = std::make_unique<BrowseEvent>();
+        event->type = "state";
+        event->state = BrowserStateName(browserState);
+
+        if (error != nullptr) {
+          event->hasError = true;
+          event->errorDomain =
+              static_cast<int32_t>(nw_error_get_error_domain(error));
+          event->errorCode = nw_error_get_error_code(error);
+        }
+
+        state->Emit(std::move(event));
+
+        // Both states are terminal, so stop delivering after reporting them.
+        if (browserState == nw_browser_state_cancelled ||
+            browserState == nw_browser_state_failed) {
+          FinishAndRelease(state);
+        }
+      });
+
+  nw_browser_set_browse_results_changed_handler(
+      browser, ^(nw_browse_result_t oldResult, nw_browse_result_t newResult,
+                 bool /* batchComplete */) {
+        auto event = std::make_unique<BrowseEvent>();
+        event->type = "result";
+
+        nw_browse_result_t current = newResult != nullptr ? newResult
+                                                          : oldResult;
+        if (current != nullptr) {
+          nw_endpoint_t endpoint = nw_browse_result_copy_endpoint(current);
+          if (endpoint != nullptr) {
+            const char *name = nw_endpoint_get_bonjour_service_name(endpoint);
+            if (name != nullptr) {
+              event->name = name;
+            }
+            nw_release(endpoint);
+          }
+        }
+
+        {
+          std::lock_guard<std::mutex> lock(state->mutex);
+          if (oldResult == nullptr && newResult != nullptr) {
+            event->change = "added";
+            state->total += 1;
+          } else if (newResult == nullptr && oldResult != nullptr) {
+            event->change = "removed";
+            if (state->total > 0) {
+              state->total -= 1;
+            }
+          } else {
+            event->change = "changed";
+          }
+          event->total = state->total;
+        }
+
+        state->Emit(std::move(event));
+      });
+
+  nw_browser_start(browser);
+
+  auto handle = std::make_unique<NativeBrowser>(browser, queue, state);
+
+  napi_value object;
+  napi_create_object(env, &object);
+  napi_property_descriptor properties[] = {
+      {"cancel", nullptr, BrowserCancel, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+  };
+  napi_define_properties(env, object, 1, properties);
+  napi_wrap(env, object, handle.get(), BrowserFinalizer, nullptr, nullptr);
+  handle.release();
+
+  return object;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+      {"startBrowse", nullptr, StartBrowse, nullptr, nullptr, nullptr,
+       napi_default, nullptr},
+  };
+
+  napi_define_properties(env, exports, 1, properties);
+  return exports;
+}
+
+} // namespace
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/net-utils-native/package.json
+++ b/packages/net-utils-native/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@arcanewizards/net-utils",
-  "version": "0.2.0",
+  "name": "@arcanewizards/net-utils-native",
+  "version": "0.1.0",
   "private": false,
   "license": "MIT",
   "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/ArcaneWizards/open-source.git",
-    "directory": "packages/net-utils"
+    "directory": "packages/net-utils-native"
   },
   "exports": {
     ".": {
@@ -19,17 +19,22 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "native/local-network-macos.mm",
+    "scripts/build-native.mjs"
   ],
   "scripts": {
-    "build": "pnpm clean && tsup && check-export-map",
-    "clean": "rm -rf dist",
+    "build": "pnpm clean && tsup && node scripts/build-native.mjs && check-export-map",
+    "clean": "rm -rf dist && rm -rf native/out",
     "check:types": "tsc --noEmit",
     "format:fix": "cd .. && pnpm format:fix",
     "lint": "eslint . --max-warnings 0",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "postinstall": "node scripts/build-native.mjs",
+    "test:integration": "pnpm build && node scripts/test-integration.mjs"
   },
   "devDependencies": {
+    "@arcanejs/protocol": "^0.9.1",
     "@arcanewizards/eslint-config": "workspace:^",
     "@arcanewizards/typescript-config": "workspace:^",
     "@types/node": "^25.5.0",

--- a/packages/net-utils-native/scripts/build-native.mjs
+++ b/packages/net-utils-native/scripts/build-native.mjs
@@ -1,0 +1,134 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFile } from 'node:child_process';
+import { homedir } from 'node:os';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Local network access is a macOS-only concern, so there is nothing to build
+// anywhere else.
+if (process.platform !== 'darwin') {
+  process.exit(0);
+}
+
+const execFilePromise = (file, args, options) => {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+  });
+};
+
+const compactPaths = (paths) => {
+  return [...new Set(paths.filter(Boolean))];
+};
+
+const nodeHeaderCandidates = () => {
+  return compactPaths([
+    process.env.npm_config_nodedir
+      ? join(process.env.npm_config_nodedir, 'include', 'node')
+      : null,
+    join(dirname(process.execPath), 'include', 'node'),
+    join(dirname(process.execPath), '..', 'include', 'node'),
+    join(
+      homedir(),
+      'Library',
+      'Caches',
+      'node-gyp',
+      process.versions.node,
+      'include',
+      'node',
+    ),
+  ]);
+};
+
+const findNodeIncludeDir = async () => {
+  const paths = nodeHeaderCandidates();
+
+  for (const candidate of paths) {
+    try {
+      await stat(join(candidate, 'node_api.h'));
+      return candidate;
+    } catch {
+      // Ignore and try the next candidate
+    }
+  }
+
+  throw new Error(`Unable to find Node headers. Tried: ${paths.join(', ')}`);
+};
+
+const macOSTargets = [
+  { clangArch: 'arm64', nodeArch: 'arm64' },
+  { clangArch: 'x86_64', nodeArch: 'x64' },
+];
+
+const buildMacOSNativeModule = async (
+  { clangArch, nodeArch },
+  nodeIncludeDir,
+  outputDir,
+) => {
+  await execFilePromise(
+    'clang++',
+    [
+      '-std=c++17',
+      '-ObjC++',
+      '-fvisibility=hidden',
+      '-DNAPI_VERSION=9',
+      // Network.framework's browser API is available from macOS 10.15.
+      '-mmacosx-version-min=10.15',
+      '-arch',
+      clangArch,
+      '-bundle',
+      '-undefined',
+      'dynamic_lookup',
+      '-I',
+      nodeIncludeDir,
+      join(root, 'native', 'local-network-macos.mm'),
+      '-framework',
+      'Network',
+      '-framework',
+      'Foundation',
+      '-framework',
+      'CoreFoundation',
+      '-o',
+      join(outputDir, `local-network-macos.${nodeArch}.node`),
+    ],
+    {
+      stdio: 'inherit',
+    },
+  );
+};
+
+const build = async () => {
+  const nodeIncludeDir = await findNodeIncludeDir();
+  const outputDir = join(root, 'native', 'out');
+  await mkdir(outputDir, { recursive: true });
+
+  await rm(join(outputDir, 'local-network-macos.node'), { force: true });
+
+  for (const target of macOSTargets) {
+    await buildMacOSNativeModule(target, nodeIncludeDir, outputDir);
+  }
+};
+
+build().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Error building native module:', error);
+  if (error.stdout) {
+    // eslint-disable-next-line no-console
+    console.error(error.stdout);
+  }
+  if (error.stderr) {
+    // eslint-disable-next-line no-console
+    console.error(error.stderr);
+  }
+  process.exit(1);
+});

--- a/packages/net-utils-native/scripts/test-integration.mjs
+++ b/packages/net-utils-native/scripts/test-integration.mjs
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+
+/**
+ * Manual integration harness for local network access.
+ *
+ * Runs a real probe against the machine's network and prints the raw event
+ * trace, so that the granted/denied decision rule can be checked against what
+ * macOS actually reports.
+ *
+ * Usage:
+ *
+ *   node scripts/test-integration.mjs [serviceType...]
+ *
+ * To exercise the denial path, revoke Local Network access for the responsible
+ * process (for a terminal run, that is the terminal application itself) in
+ * System Settings > Privacy & Security > Local Network, then run this again.
+ */
+import { probeLocalNetworkAccess, DEFAULT_SERVICE_TYPES } from '../dist/index.js';
+
+const serviceTypes =
+  process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_SERVICE_TYPES;
+
+const main = async () => {
+  if (process.platform !== 'darwin') {
+    console.log('Local network access probing is only supported on macOS.');
+    return;
+  }
+
+  console.log(`Browsing for: ${serviceTypes.join(', ')}`);
+  console.log('');
+
+  const started = Date.now();
+  const result = await probeLocalNetworkAccess({ serviceTypes });
+  const elapsed = Date.now() - started;
+
+  for (const event of result.events) {
+    if (event.type === 'state') {
+      const error = event.error
+        ? ` error=${event.error.domain}/${event.error.code}`
+        : '';
+      console.log(`  state  ${event.serviceType.padEnd(22)} ${event.state}${error}`);
+    } else {
+      console.log(
+        `  result ${event.serviceType.padEnd(22)} ${event.change} total=${event.total} ${event.name ?? ''}`,
+      );
+    }
+  }
+
+  console.log('');
+  console.log(`access:      ${result.access}`);
+  console.log(`reason:      ${result.reason}`);
+  console.log(`resultCount: ${result.resultCount}`);
+  console.log(`errors:      ${JSON.stringify(result.errors)}`);
+  console.log(`elapsed:     ${elapsed}ms`);
+
+  if (result.access === 'denied') {
+    process.exitCode = 1;
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/net-utils-native/src/errors.ts
+++ b/packages/net-utils-native/src/errors.ts
@@ -1,0 +1,92 @@
+import type { LocalNetworkBrowseError } from './types.js';
+
+export type LocalNetworkErrorCode =
+  | 'ERR_LOCAL_NETWORK_NOT_SUPPORTED'
+  | 'ERR_LOCAL_NETWORK_DENIED'
+  | 'ERR_LOCAL_NETWORK_INVALID_ARGUMENT'
+  | 'ERR_LOCAL_NETWORK_NATIVE';
+
+export type LocalNetworkErrorOptions = {
+  cause?: unknown;
+};
+
+export class LocalNetworkError extends Error {
+  readonly code: LocalNetworkErrorCode;
+
+  constructor(
+    code: LocalNetworkErrorCode,
+    message: string,
+    options: LocalNetworkErrorOptions = {},
+  ) {
+    super(message, options);
+    this.name = 'LocalNetworkError';
+    this.code = code;
+  }
+}
+
+export class LocalNetworkNotSupportedError extends LocalNetworkError {
+  constructor(message: string, options?: LocalNetworkErrorOptions) {
+    super('ERR_LOCAL_NETWORK_NOT_SUPPORTED', message, options);
+    this.name = 'LocalNetworkNotSupportedError';
+  }
+}
+
+export class LocalNetworkDeniedError extends LocalNetworkError {
+  readonly errors: LocalNetworkBrowseError[];
+
+  constructor(
+    message: string,
+    options: LocalNetworkErrorOptions & {
+      errors?: LocalNetworkBrowseError[];
+    } = {},
+  ) {
+    super('ERR_LOCAL_NETWORK_DENIED', message, options);
+    this.name = 'LocalNetworkDeniedError';
+    this.errors = options.errors ?? [];
+  }
+}
+
+export class LocalNetworkInvalidArgumentError extends LocalNetworkError {
+  readonly argument: string | undefined;
+
+  constructor(
+    message: string,
+    options: LocalNetworkErrorOptions & {
+      argument?: string;
+    } = {},
+  ) {
+    super('ERR_LOCAL_NETWORK_INVALID_ARGUMENT', message, options);
+    this.name = 'LocalNetworkInvalidArgumentError';
+    this.argument = options.argument;
+  }
+}
+
+export class LocalNetworkNativeError extends LocalNetworkError {
+  readonly operation: string | undefined;
+
+  constructor(
+    message: string,
+    options: LocalNetworkErrorOptions & {
+      operation?: string;
+    } = {},
+  ) {
+    super('ERR_LOCAL_NETWORK_NATIVE', message, options);
+    this.name = 'LocalNetworkNativeError';
+    this.operation = options.operation;
+  }
+}
+
+export const toLocalNetworkNativeError = (
+  error: unknown,
+  message: string,
+  operation?: string,
+) => {
+  if (error instanceof LocalNetworkError) {
+    return error;
+  }
+
+  return new LocalNetworkNativeError(message, {
+    cause: error,
+    operation,
+  });
+};

--- a/packages/net-utils-native/src/index.ts
+++ b/packages/net-utils-native/src/index.ts
@@ -1,0 +1,259 @@
+import type { Logger } from '@arcanejs/protocol/logging';
+
+import { loadNativeModuleMacOS, callNative } from './local-network-macos.js';
+import type { NativeBrowseEvent } from './local-network-macos.js';
+import { LocalNetworkDeniedError } from './errors.js';
+import type {
+  LocalNetworkAccess,
+  LocalNetworkBrowseError,
+  LocalNetworkBrowseEvent,
+  LocalNetworkBrowserState,
+  LocalNetworkErrorDomain,
+  LocalNetworkProbeOptions,
+  LocalNetworkProbeResult,
+} from './types.js';
+
+export {
+  LocalNetworkDeniedError,
+  LocalNetworkError,
+  LocalNetworkInvalidArgumentError,
+  LocalNetworkNativeError,
+  LocalNetworkNotSupportedError,
+} from './errors.js';
+
+export type {
+  LocalNetworkErrorCode,
+  LocalNetworkErrorOptions,
+} from './errors.js';
+
+export type {
+  LocalNetworkAccess,
+  LocalNetworkBrowseError,
+  LocalNetworkBrowseEvent,
+  LocalNetworkBrowserState,
+  LocalNetworkErrorDomain,
+  LocalNetworkProbeOptions,
+  LocalNetworkProbeResult,
+} from './types.js';
+
+/**
+ * `kDNSServiceErr_PolicyDenied` from `<dns_sd.h>`.
+ *
+ * This is what macOS reports when local network access has been denied, as
+ * opposed to a transient discovery failure.
+ */
+const DNS_ERROR_POLICY_DENIED = -65570;
+
+/**
+ * Service types browsed by default.
+ *
+ * Browsing any type is enough to make macOS evaluate local network access, but
+ * discovering something is the only positive confirmation that access was
+ * actually granted, so the defaults favour types that are commonly present.
+ *
+ * Every type listed here must also appear in the application's
+ * `NSBonjourServices` Info.plist entry.
+ */
+export const DEFAULT_SERVICE_TYPES = [
+  '_airplay._tcp',
+  '_raop._tcp',
+  '_companion-link._tcp',
+  '_googlecast._tcp',
+  '_http._tcp',
+];
+
+const DEFAULT_TIMEOUT_MS = 2500;
+
+const BROWSER_STATES: LocalNetworkBrowserState[] = [
+  'invalid',
+  'ready',
+  'failed',
+  'cancelled',
+  'waiting',
+];
+
+const ERROR_DOMAINS: LocalNetworkErrorDomain[] = [
+  'invalid',
+  'posix',
+  'dns',
+  'tls',
+  'wifi-aware',
+];
+
+const toBrowserState = (
+  value: string | undefined,
+): LocalNetworkBrowserState => {
+  const state = BROWSER_STATES.find((candidate) => candidate === value);
+  return state ?? 'invalid';
+};
+
+const toErrorDomain = (value: number | undefined): LocalNetworkErrorDomain => {
+  if (value === undefined) {
+    return 'unknown';
+  }
+  return ERROR_DOMAINS[value] ?? 'unknown';
+};
+
+const toChange = (value: string | undefined) => {
+  return value === 'added' || value === 'removed' ? value : 'changed';
+};
+
+const isPolicyDenial = (error: LocalNetworkBrowseError) => {
+  return error.domain === 'dns' && error.code === DNS_ERROR_POLICY_DENIED;
+};
+
+const describeError = (error: LocalNetworkBrowseError) => {
+  return `${error.serviceType} (${error.domain} ${error.code})`;
+};
+
+/**
+ * Browses for Bonjour services using Apple's `NWBrowser` API.
+ *
+ * Browsing is the operation macOS uses to evaluate local network access, so
+ * this both raises the permission prompt (attributed to the containing
+ * application bundle) and reports back what the system decided.
+ *
+ * Unlike a pure-JavaScript mDNS implementation sending multicast over `dgram`,
+ * a denial here is visible rather than silent.
+ */
+export const probeLocalNetworkAccess = async (
+  options: LocalNetworkProbeOptions = {},
+): Promise<LocalNetworkProbeResult> => {
+  const {
+    serviceTypes = DEFAULT_SERVICE_TYPES,
+    domain = null,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+  } = options;
+
+  const native = loadNativeModuleMacOS();
+
+  const events: LocalNetworkBrowseEvent[] = [];
+  const errors: LocalNetworkBrowseError[] = [];
+  const totals = new Map<string, number>();
+
+  const handles = serviceTypes.map((serviceType) => {
+    const onEvent = (event: NativeBrowseEvent) => {
+      if (event.type === 'state') {
+        const state = toBrowserState(event.state);
+        const error =
+          event.errorCode === undefined
+            ? undefined
+            : {
+                serviceType,
+                domain: toErrorDomain(event.errorDomain),
+                code: event.errorCode,
+              };
+
+        if (error) {
+          errors.push(error);
+        }
+
+        events.push({ type: 'state', serviceType, state, error });
+        return;
+      }
+
+      const total = event.total ?? 0;
+      totals.set(serviceType, total);
+      events.push({
+        type: 'result',
+        serviceType,
+        change: toChange(event.change),
+        name: event.name,
+        total,
+      });
+    };
+
+    return callNative('startBrowse', () =>
+      native.startBrowse(serviceType, domain, onEvent),
+    );
+  });
+
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, timeoutMs);
+  });
+
+  for (const handle of handles) {
+    // Cancelling is best effort: a browser that already failed is gone, and
+    // there is nothing useful to do about a failure to tear one down.
+    try {
+      handle.cancel();
+    } catch {
+      // Ignore.
+    }
+  }
+
+  const resultCount = [...totals.values()].reduce(
+    (sum, total) => sum + total,
+    0,
+  );
+
+  const denials = errors.filter(isPolicyDenial);
+
+  let access: LocalNetworkAccess;
+  let reason: string;
+
+  if (denials.length > 0) {
+    access = 'denied';
+    reason = `Local network access was denied by the operating system: ${denials
+      .map(describeError)
+      .join(', ')}`;
+  } else if (resultCount > 0) {
+    access = 'granted';
+    reason = `Discovered ${resultCount} local network service(s).`;
+  } else if (errors.length > 0) {
+    access = 'unknown';
+    reason = `Discovered no local network services, and browsing failed: ${errors
+      .map(describeError)
+      .join(', ')}`;
+  } else {
+    access = 'unknown';
+    // Observed on macOS 26: when access is denied, browsing still reaches
+    // `ready` and reports no error at all, it simply never discovers anything.
+    // That is indistinguishable from a network with nothing to discover, so
+    // this stays inconclusive rather than being treated as a denial.
+    reason =
+      'Discovered no local network services. This is expected on a network with nothing to discover, but is also how a denial presents itself.';
+  }
+
+  return { access, reason, resultCount, errors, events };
+};
+
+/**
+ * Ensures that local network access is available on the machine,
+ * which is required for some platforms (e.g. macOS).
+ *
+ * Rejects when access was explicitly denied. An inconclusive probe resolves, so
+ * that a network with nothing to discover does not prevent a connection from
+ * being attempted.
+ */
+export const ensureLocalNetworkAccess = async (
+  logger: Logger | null = null,
+  options: LocalNetworkProbeOptions = {},
+): Promise<void> => {
+  if (process.platform !== 'darwin') {
+    // Local network access only needs to be requested on macOS.
+    return;
+  }
+
+  logger?.info('Ensuring local network access is available...');
+
+  const result = await probeLocalNetworkAccess(options);
+
+  logger?.debug(
+    `Local network probe: ${result.access} - ${result.reason}`,
+    result.events,
+  );
+
+  if (result.access === 'denied') {
+    throw new LocalNetworkDeniedError(result.reason, { errors: result.errors });
+  }
+
+  if (result.access === 'unknown') {
+    logger?.warn(
+      `Local network access could not be confirmed. ${result.reason}`,
+    );
+    return;
+  }
+
+  logger?.info(`Local network access is available. ${result.reason}`);
+};

--- a/packages/net-utils-native/src/local-network-macos.ts
+++ b/packages/net-utils-native/src/local-network-macos.ts
@@ -1,0 +1,134 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { dirname } from 'node:path';
+
+import {
+  LocalNetworkNativeError,
+  toLocalNetworkNativeError,
+} from './errors.js';
+
+/**
+ * Raw event shape emitted by `native/local-network-macos.mm`.
+ */
+export type NativeBrowseEvent = {
+  type: 'state' | 'result';
+  state?: string;
+  change?: string;
+  name?: string;
+  total?: number;
+  errorDomain?: number;
+  errorCode?: number;
+};
+
+export type NativeBrowseHandle = {
+  cancel(): void;
+};
+
+export type NativeLocalNetworkModule = {
+  startBrowse(
+    serviceType: string,
+    domain: string | null,
+    callback: (event: NativeBrowseEvent) => void,
+  ): NativeBrowseHandle;
+};
+
+const requireNative = createRequire(join(process.cwd(), 'package.json'));
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const assertFunction = (value: unknown, name: string) => {
+  if (typeof value !== 'function') {
+    throw new LocalNetworkNativeError(
+      `MacOS local network native module is missing ${name}.`,
+    );
+  }
+};
+
+export const callNative = <Value>(
+  operation: string,
+  callback: () => Value,
+): Value => {
+  try {
+    return callback();
+  } catch (error) {
+    throw toLocalNetworkNativeError(
+      error,
+      `MacOS local network native operation ${operation} failed.`,
+      operation,
+    );
+  }
+};
+
+const getNativeModule = () => {
+  const packageRootCandidates: string[] = [];
+
+  try {
+    packageRootCandidates.push(
+      dirname(
+        requireNative.resolve('@arcanewizards/net-utils-native/package.json'),
+      ),
+    );
+  } catch {
+    // Fall through to local path candidates.
+  }
+
+  if (typeof __dirname === 'string') {
+    packageRootCandidates.push(join(__dirname, '..'));
+  }
+
+  packageRootCandidates.push(process.cwd());
+  packageRootCandidates.push(
+    join(process.cwd(), 'packages', 'net-utils-native'),
+  );
+
+  const resolvedPaths = new Set(
+    packageRootCandidates.map((packageRoot) =>
+      join(
+        packageRoot,
+        'native',
+        'out',
+        `local-network-macos.${process.arch}.node`,
+      ),
+    ),
+  );
+
+  for (const nativePath of resolvedPaths) {
+    if (existsSync(nativePath)) {
+      return callNative('loadNativeModule', () => requireNative(nativePath));
+    }
+  }
+
+  throw new LocalNetworkNativeError(
+    `MacOS local network native module was not found. Tried: ${[
+      ...resolvedPaths,
+    ].join(', ')}`,
+  );
+};
+
+const assertNativeModule = (value: unknown): NativeLocalNetworkModule => {
+  if (!isRecord(value)) {
+    throw new LocalNetworkNativeError(
+      'MacOS local network native module did not load correctly.',
+    );
+  }
+
+  assertFunction(value.startBrowse, 'startBrowse');
+
+  return value as unknown as NativeLocalNetworkModule;
+};
+
+/**
+ * Ensure only a singleton instance exists, and that the native module is only
+ * loaded when it is actually needed.
+ */
+let nativeModule: NativeLocalNetworkModule | null = null;
+
+export const loadNativeModuleMacOS = (): NativeLocalNetworkModule => {
+  if (!nativeModule) {
+    nativeModule = assertNativeModule(getNativeModule());
+  }
+  return nativeModule;
+};

--- a/packages/net-utils-native/src/types.ts
+++ b/packages/net-utils-native/src/types.ts
@@ -1,0 +1,91 @@
+/**
+ * States reported by `NWBrowser`, mirroring `nw_browser_state_t`.
+ *
+ * `failed` and `cancelled` are terminal.
+ */
+export type LocalNetworkBrowserState =
+  | 'invalid'
+  | 'ready'
+  | 'failed'
+  | 'cancelled'
+  | 'waiting';
+
+/**
+ * Error domains reported by `NWBrowser`, mirroring `nw_error_domain_t`.
+ */
+export type LocalNetworkErrorDomain =
+  | 'invalid'
+  | 'posix'
+  | 'dns'
+  | 'tls'
+  | 'wifi-aware'
+  | 'unknown';
+
+export type LocalNetworkBrowseError = {
+  serviceType: string;
+  domain: LocalNetworkErrorDomain;
+  /**
+   * Meaning depends on `domain`: a POSIX errno for `posix`, and a
+   * `DNSServiceErrorType` (as defined in `dns_sd.h`) for `dns`.
+   */
+  code: number;
+};
+
+export type LocalNetworkBrowseEvent =
+  | {
+      type: 'state';
+      serviceType: string;
+      state: LocalNetworkBrowserState;
+      error?: LocalNetworkBrowseError;
+    }
+  | {
+      type: 'result';
+      serviceType: string;
+      change: 'added' | 'removed' | 'changed';
+      name?: string;
+      total: number;
+    };
+
+/**
+ * Whether the operating system allows this process to reach the local network.
+ *
+ * `unknown` means the probe completed without being denied, but also without
+ * discovering anything, so access could not be positively confirmed. This is
+ * expected on a network with no discoverable Bonjour services.
+ */
+export type LocalNetworkAccess = 'granted' | 'denied' | 'unknown';
+
+export type LocalNetworkProbeOptions = {
+  /**
+   * Bonjour service types to browse for. Every type declared here should also
+   * appear in the application's `NSBonjourServices` Info.plist entry.
+   */
+  serviceTypes?: string[];
+  /**
+   * Bonjour domain to browse, or `null` for the default domains.
+   */
+  domain?: string | null;
+  /**
+   * How long to browse before deciding. Discovery is not instant, so this needs
+   * to be long enough for responses to arrive.
+   */
+  timeoutMs?: number;
+};
+
+export type LocalNetworkProbeResult = {
+  access: LocalNetworkAccess;
+  /**
+   * Human readable explanation of how `access` was decided, for logging.
+   */
+  reason: string;
+  /**
+   * Number of distinct services discovered across all browsed service types.
+   */
+  resultCount: number;
+  errors: LocalNetworkBrowseError[];
+  /**
+   * Every event observed during the probe, in order. Retained so that the
+   * decision rule can be reviewed against real-world behaviour.
+   */
+  events: LocalNetworkBrowseEvent[];
+};

--- a/packages/net-utils-native/tsconfig.json
+++ b/packages/net-utils-native/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@arcanewizards/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "nodenext",
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"],
+}

--- a/packages/net-utils-native/tsup.config.ts
+++ b/packages/net-utils-native/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  splitting: true,
+  dts: true,
+  external: [],
+});

--- a/packages/net-utils/src/index.ts
+++ b/packages/net-utils/src/index.ts
@@ -1,6 +1,4 @@
-import Bonjour from 'bonjour-service';
 import os from 'os';
-import type { Logger } from '@arcanejs/protocol/logging';
 
 export type NetworkTarget =
   | {
@@ -70,39 +68,4 @@ export const getNetworkInterfaces = async (): Promise<
     }
   }
   return results;
-};
-
-/**
- * Ensures that local network access is available on the machine,
- * which is required for some platforms (e.g. macOS).
- */
-export const ensureLocalNetworkAccess = (
-  logger: Logger | null = null,
-  waitForMs: number = 2000,
-): Promise<void> => {
-  if (process.platform !== 'darwin') {
-    // Using bonjour for local network access check is only required on macOS
-    return Promise.resolve();
-  }
-  return new Promise((resolve, reject) => {
-    try {
-      logger?.info('Ensuring local network access is available...');
-      const bonjour = new Bonjour({}, (cause: unknown) => {
-        const error = new Error('Failed to access local network', { cause });
-        reject(error);
-      });
-      const browser = bonjour.find({ type: 'http' });
-      // Consider ready only after a short delay,
-      // to allow for the bonjour service to start,
-      // and for any errors to be reported via the error callback.
-      setTimeout(() => {
-        browser.stop();
-        bonjour.destroy();
-        resolve();
-      }, waitForMs);
-    } catch (cause) {
-      const error = new Error('Failed to access local network', { cause });
-      reject(error);
-    }
-  });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,9 +43,9 @@ importers:
       '@arcanewizards/midi':
         specifier: workspace:^
         version: link:../../packages/midi
-      bonjour-service:
-        specifier: ^1.4.4
-        version: 1.4.4
+      '@arcanewizards/net-utils-native':
+        specifier: workspace:^
+        version: link:../../packages/net-utils-native
       pino:
         specifier: ^9.14.0
         version: 9.14.0
@@ -164,6 +164,9 @@ importers:
       '@arcanewizards/midi':
         specifier: workspace:^
         version: link:../../packages/midi
+      '@arcanewizards/net-utils-native':
+        specifier: workspace:^
+        version: link:../../packages/net-utils-native
       bindings:
         specifier: ^1.5.0
         version: 1.5.0
@@ -486,14 +489,34 @@ importers:
         version: 5.9.3
 
   packages/net-utils:
-    dependencies:
+    devDependencies:
+      '@arcanewizards/eslint-config':
+        specifier: workspace:^
+        version: link:../eslint-config
+      '@arcanewizards/typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      check-export-map:
+        specifier: ^1.3.1
+        version: 1.3.1
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/net-utils-native:
+    devDependencies:
       '@arcanejs/protocol':
         specifier: ^0.9.1
         version: 0.9.1
-      bonjour-service:
-        specifier: ^1.4.4
-        version: 1.4.4
-    devDependencies:
       '@arcanewizards/eslint-config':
         specifier: workspace:^
         version: link:../eslint-config
@@ -1706,9 +1729,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@leichtgewicht/ip-codec@2.0.5':
-    resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
 
   '@listr2/prompt-adapter-inquirer@2.0.22':
     resolution: {integrity: sha512-hV36ZoY+xKL6pYOt1nPNnkciFkn89KZwqLhAFzJvYysAvL5uBQdiADZx/8bIDXIukzzwG0QlPYolgMzQUtKgpQ==}
@@ -3155,6 +3175,7 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3400,9 +3421,6 @@ packages:
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  bonjour-service@1.4.4:
-    resolution: {integrity: sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==}
 
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
@@ -3753,10 +3771,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  dns-packet@5.6.1:
-    resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
-    engines: {node: '>=6'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -5253,10 +5267,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multicast-dns@7.2.5:
-    resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
-    hasBin: true
-
   murmur-32@0.2.0:
     resolution: {integrity: sha512-ZkcWZudylwF+ir3Ld1n7gL6bI2mQAzXvSobPwVtu8aYi2sbXeipeSkdcanRLzIofLcM5F53lGaKm2dk7orBi7Q==}
 
@@ -6243,9 +6253,6 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
-
-  thunky@1.1.0:
-    resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
   tiny-each-async@2.0.3:
     resolution: {integrity: sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==}
@@ -8115,8 +8122,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@leichtgewicht/ip-codec@2.0.5': {}
-
   '@listr2/prompt-adapter-inquirer@2.0.22(@inquirer/prompts@6.0.1)':
     dependencies:
       '@inquirer/prompts': 6.0.1
@@ -9792,11 +9797,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bonjour-service@1.4.4:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      multicast-dns: 7.2.5
-
   boolean@3.2.0:
     optional: true
 
@@ -10097,10 +10097,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  dns-packet@5.6.1:
-    dependencies:
-      '@leichtgewicht/ip-codec': 2.0.5
 
   doctrine@2.1.0:
     dependencies:
@@ -12057,11 +12053,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multicast-dns@7.2.5:
-    dependencies:
-      dns-packet: 5.6.1
-      thunky: 1.1.0
-
   murmur-32@0.2.0:
     dependencies:
       encode-utf8: 1.0.3
@@ -13172,8 +13163,6 @@ snapshots:
   thread-stream@3.1.0:
     dependencies:
       real-require: 0.2.0
-
-  thunky@1.1.0: {}
 
   tiny-each-async@2.0.3:
     optional: true

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "native/out/**"]
     },
     "clean": {
       "dependsOn": ["^clean"]


### PR DESCRIPTION
Use native MacOS API to request local network access

On some macs, despite the 2 releases since 0.4.7,
local network access was still blocked.

We're now trying a different approach to request local network access when it's
needed that should, hopefully, resolve the issue